### PR TITLE
Hotfix: Travis configuration missing space

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ after_success:
   - curl https://deepsource.io/cli | sh
   - export DEEPSOURCE_DSN=https://sampledsn@deepsource.io
   # Report coverage artifact to 'test-coverage' analyzer
-  -./bin/deepsource report --analyzer test-coverage --key python --value-file ./coverage.xml
+  - ./bin/deepsource report --analyzer test-coverage --key python --value-file ./coverage.xml
 
 # Assuming you have installed the travis-ci CLI tool, after you
 # create the Github repo and add it to Travis, run the

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,13 +15,13 @@ script: tox
 
 # Upload test coverage reports (codecov and deepsource)
 after_success:
-# Upload coverage to codecov
-- bash <(curl -s https://codecov.io/bash)
-# Install deepsource CLI
-- curl https://deepsource.io/cli | sh
-- export DEEPSOURCE_DSN=https://sampledsn@deepsource.io
-# Report coverage artifact to 'test-coverage' analyzer
--./bin/deepsource report --analyzer test-coverage --key python --value-file ./coverage.xml
+  # Upload coverage to codecov
+  - bash <(curl -s https://codecov.io/bash)
+  # Install deepsource CLI
+  - curl https://deepsource.io/cli | sh
+  - export DEEPSOURCE_DSN=https://sampledsn@deepsource.io
+  # Report coverage artifact to 'test-coverage' analyzer
+  -./bin/deepsource report --analyzer test-coverage --key python --value-file ./coverage.xml
 
 # Assuming you have installed the travis-ci CLI tool, after you
 # create the Github repo and add it to Travis, run the


### PR DESCRIPTION
Looks like I accidentally removed a space in the configuration file for Travis which may have broken builds! This should fix it and the build should run on the PR. This is a very minor change and will merge in unless there are objections.