### PR TITLE
DOC: Add Badges To Readme + Center Heading

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,18 +1,18 @@
 .. raw:: html
 
    <p align="center">
-     <img width="450" height="200" src=https://warwick.ac.uk/fac/sci/dcs/research/tia/tiatoolbox/files/tialab_logo.png>
+     <img width="450" height="200" src="https://warwick.ac.uk/fac/sci/dcs/research/tia/tiatoolbox/files/tialab_logo.png">
    </p>
    <h1 align="center">TIA Toolbox</h1>
    <p align="center">
-     <a href='https://tia-toolbox.readthedocs.io/en/latest/?badge=latest'>
-       <img src='https://readthedocs.org/projects/tia-toolbox/badge/?version=latest' alt='Documentation Status' />
+     <a href="https://tia-toolbox.readthedocs.io/en/latest/?badge=latest">
+       <img src="https://readthedocs.org/projects/tia-toolbox/badge/?version=latest" alt="Documentation Status" />
      </a>
-     <a href='https://travis-ci.org/TIA-Lab/tiatoolbox'>
-       <img src='https://travis-ci.org/TIA-Lab/tiatoolbox.svg?branch=master' alt='Travis CI Status' />
+     <a href="https://travis-ci.org/TIA-Lab/tiatoolbox">
+       <img src="https://travis-ci.org/TIA-Lab/tiatoolbox.svg?branch=master" alt="Travis CI Status" />
      </a>
-     <a href='https://badge.fury.io/py/tiatoolbox'>
-       <img src='https://badge.fury.io/py/tiatoolbox.svg' alt='PyPI Status' />
+     <a href="https://badge.fury.io/py/tiatoolbox">
+       <img src="https://badge.fury.io/py/tiatoolbox.svg" alt="PyPI Status" />
      </a>
    </p>
 

--- a/README.rst
+++ b/README.rst
@@ -3,10 +3,19 @@
    <p align="center">
      <img width="450" height="200" src=https://warwick.ac.uk/fac/sci/dcs/research/tia/tiatoolbox/files/tialab_logo.png>
    </p>
+   <h1 align="center">TIA Toolbox</h1>
+   <p align="center">
+     <a href='https://tia-toolbox.readthedocs.io/en/latest/?badge=latest'>
+       <img src='https://readthedocs.org/projects/tia-toolbox/badge/?version=latest' alt='Documentation Status' />
+     </a>
+     <a href='https://travis-ci.org/TIA-Lab/tiatoolbox'>
+       <img src='https://travis-ci.org/TIA-Lab/tiatoolbox.svg?branch=master' alt='Travis CI Status' />
+     </a>
+     <a href='https://badge.fury.io/py/tiatoolbox'>
+       <img src='https://badge.fury.io/py/tiatoolbox.svg' alt='PyPI Status' />
+     </a>
+   </p>
 
-===========
-TIA Toolbox
-===========
 
 Computational Pathology Toolbox developed by TIA Lab
 


### PR DESCRIPTION
- Add badges to readme for Read The Docs, Travis CI, PyPI.
- Move Heading below logo.
- Change heading to be raw HTML and be centred.

Opening as a PR to test that docs building is not adversely affected.