### PR TITLE
API: Restructure WSIReader to allow support for additional formats

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -21,6 +21,13 @@ dataloader.wsireader
     :special-members: __init__
     :show-inheritance:
 
+^^^^^^^^^^^^^^^^^^
+dataloader.wsimeta
+^^^^^^^^^^^^^^^^^^
+
+.. automodule:: tiatoolbox.dataloader.wsimeta
+    :members: WSIMeta
+
 ^^^^^^^^^^^^^^^^^^^^^
 dataloader.slide_info
 ^^^^^^^^^^^^^^^^^^^^^

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -17,8 +17,9 @@ dataloader.wsireader
 ^^^^^^^^^^^^^^^^^^^^
 
 .. automodule:: tiatoolbox.dataloader.wsireader
-    :members: WSIReader
+    :members: WSIReader, OpenSlideWSIReader
     :special-members: __init__
+    :show-inheritance:
 
 ^^^^^^^^^^^^^^^^^^^^^
 dataloader.slide_info

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -63,3 +63,9 @@ utils.transforms
 ^^^^^^^^^^
 .. automodule:: tiatoolbox.utils.transforms
     :members: background_composite
+
+^^^^^^^^^^
+utils.exceptions
+^^^^^^^^^^
+.. automodule:: tiatoolbox.utils.exceptions
+    :members: FileNotSupported

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -56,13 +56,13 @@ Utils
 utils.misc
 ^^^^^^^^^^
 .. automodule:: tiatoolbox.utils.misc
-    :members: save_yaml, split_path_name_ext, grab_files_from_dir, imwrite, imresize
+    :members: save_yaml, split_path_name_ext, grab_files_from_dir, imwrite
 
 ^^^^^^^^^^
 utils.transforms
 ^^^^^^^^^^
 .. automodule:: tiatoolbox.utils.transforms
-    :members: background_composite
+    :members: background_composite, imresize
 
 ^^^^^^^^^^
 utils.exceptions

--- a/tests/test_tiatoolbox.py
+++ b/tests/test_tiatoolbox.py
@@ -7,6 +7,7 @@ from tiatoolbox.dataloader.slide_info import slide_info
 from tiatoolbox.dataloader.save_tiles import save_tiles
 from tiatoolbox.dataloader import wsireader
 from tiatoolbox import utils
+from tiatoolbox.utils.exceptions import FileNotSupported
 from tiatoolbox import cli
 from tiatoolbox import __version__
 
@@ -236,7 +237,7 @@ def test_save_tiles(_response_ndpi, _response_svs):
 
 
 def test_save_tiles_unwrap(_response_svs):
-    file_types = ("*.svs", "*.mrxs")
+    file_types = "*.svs"
     files_all = utils.misc.grab_files_from_dir(
         input_path=str(pathlib.Path(__file__).parent), file_types=file_types,
     )
@@ -268,6 +269,25 @@ def test_save_tiles_unwrap(_response_svs):
             .joinpath("Tile_5_0_0.jpg")
             .exists()
     )
+    shutil.rmtree(pathlib.Path(__file__).parent.joinpath("tiles_save_tiles"))
+
+
+def test_exception_tests():
+    unwrapped_slide_info = slide_info.__closure__[0].cell_contents
+    with pytest.raises(FileNotSupported):
+        utils.misc.save_yaml(
+            unwrapped_slide_info(input_path="/mnt/test/sample.txt", verbose=True),
+            "test.yaml")
+
+    unwrapped_save_tiles = save_tiles.__closure__[0].cell_contents
+    with pytest.raises(FileNotSupported):
+        unwrapped_save_tiles(
+            input_path="/mnt/test/sample.txt",
+            tile_objective_value=5,
+            output_dir=str(pathlib.Path(__file__).parent.joinpath("tiles_save_tiles")),
+            verbose=True,
+        )
+
 
 
 # -------------------------------------------------------------------------------------

--- a/tests/test_tiatoolbox.py
+++ b/tests/test_tiatoolbox.py
@@ -83,8 +83,8 @@ def test_wsireader_slide_info(_response_svs):
         input_path=str(pathlib.Path(__file__).parent), file_types=file_types,
     )
     input_dir, file_name, ext = utils.misc.split_path_name_ext(str(files_all[0]))
-    wsi_obj = wsireader.WSIReader(input_dir, file_name + ext)
-    slide_param = wsi_obj.slide_info()
+    wsi_obj = wsireader.OpenSlideWSIReader(input_dir, file_name + ext)
+    slide_param = wsi_obj.slide_info
     utils.misc.save_yaml(slide_param, slide_param["file_name"] + ".yaml")
 
 
@@ -95,7 +95,7 @@ def test_wsireader_read_region(_response_svs):
         input_path=str(pathlib.Path(__file__).parent), file_types=file_types,
     )
     input_dir, file_name, ext = utils.misc.split_path_name_ext(str(files_all[0]))
-    wsi_obj = wsireader.WSIReader(input_dir, file_name + ext)
+    wsi_obj = wsireader.OpenSlideWSIReader(input_dir, file_name + ext)
     level = 0
     region = [13000, 17000, 15000, 19000]
     im_region = wsi_obj.read_region(region[0], region[1], region[2], region[3], level)
@@ -112,7 +112,7 @@ def test_wsireader_slide_thumbnail(_response_svs):
         input_path=str(pathlib.Path(__file__).parent), file_types=file_types,
     )
     input_dir, file_name, ext = utils.misc.split_path_name_ext(str(files_all[0]))
-    wsi_obj = wsireader.WSIReader(input_dir, file_name + ext)
+    wsi_obj = wsireader.OpenSlideWSIReader(input_dir, file_name + ext)
     slide_thumbnail = wsi_obj.slide_thumbnail()
     assert isinstance(slide_thumbnail, np.ndarray)
     assert slide_thumbnail.dtype == "uint8"
@@ -141,10 +141,11 @@ def test_wsireader_save_tiles(_response_svs):
         input_path=str(pathlib.Path(__file__).parent), file_types=file_types,
     )
     input_dir, file_name, ext = utils.misc.split_path_name_ext(str(files_all[0]))
-    wsi_obj = wsireader.WSIReader(
+    wsi_obj = wsireader.OpenSlideWSIReader(
         input_dir,
         file_name + ext,
         output_dir=str(pathlib.Path(__file__).parent.joinpath("tiles")),
+        tile_objective_value=5,
     )
     wsi_obj.save_tiles()
     assert (
@@ -165,7 +166,7 @@ def test_wsireader_save_tiles(_response_svs):
         pathlib.Path(__file__)
         .parent.joinpath("tiles")
         .joinpath("CMU-1-Small-Region.svs")
-        .joinpath("Tile_20_0_0.jpg")
+        .joinpath("Tile_5_0_0.jpg")
         .exists()
     )
     shutil.rmtree(pathlib.Path(__file__).parent.joinpath("tiles"))
@@ -180,6 +181,7 @@ def test_save_tiles(_response_ndpi, _response_svs):
     save_tiles(
         input_path=files_all,
         workers=2,
+        tile_objective_value=5,
         output_dir=str(pathlib.Path(__file__).parent.joinpath("tiles_save_tiles")),
     )
     assert (
@@ -200,7 +202,7 @@ def test_save_tiles(_response_ndpi, _response_svs):
         pathlib.Path(__file__)
         .parent.joinpath("tiles_save_tiles")
         .joinpath("CMU-1-Small-Region.svs")
-        .joinpath("Tile_20_0_0.jpg")
+        .joinpath("Tile_5_0_0.jpg")
         .exists()
     )
     assert (
@@ -221,7 +223,7 @@ def test_save_tiles(_response_ndpi, _response_svs):
         pathlib.Path(__file__)
         .parent.joinpath("tiles_save_tiles")
         .joinpath("CMU-1.ndpi")
-        .joinpath("Tile_20_0_0.jpg")
+        .joinpath("Tile_5_0_0.jpg")
         .exists()
     )
     shutil.rmtree(pathlib.Path(__file__).parent.joinpath("tiles_save_tiles"))
@@ -328,6 +330,8 @@ def test_command_line_save_tiles(_response_ndpi, _response_svs):
             '"*.ndpi, *.svs"',
             "--workers",
             "2",
+            "--tile_objective_value",
+            "5",
         ],
     )
 

--- a/tests/test_tiatoolbox.py
+++ b/tests/test_tiatoolbox.py
@@ -345,7 +345,7 @@ def test_command_line_slide_info(_response_ndpi, _response_svs):
             "--workers",
             "2",
             "--mode",
-            "save",
+            "show",
         ],
     )
 
@@ -377,6 +377,24 @@ def test_command_line_read_region(_response_ndpi):
 
     assert read_region_result.exit_code == 0
     assert os.path.isfile(str(pathlib.Path(__file__).parent.joinpath("im_region.jpg")))
+
+    read_region_result = runner.invoke(
+        cli.main,
+        [
+            "read-region",
+            "--wsi_input",
+            str(pathlib.Path(__file__).parent.joinpath("CMU-1.ndpi")),
+            "--level",
+            "0",
+            "--mode",
+            "save",
+            "--output_path",
+            str(pathlib.Path(__file__).parent.joinpath("im_region2.jpg")),
+        ],
+    )
+
+    assert read_region_result.exit_code == 0
+    assert os.path.isfile(str(pathlib.Path(__file__).parent.joinpath("im_region2.jpg")))
 
 
 def test_command_line_slide_thumbnail(_response_ndpi):
@@ -418,3 +436,24 @@ def test_command_line_save_tiles(_response_ndpi, _response_svs):
     )
 
     assert save_tiles_result.exit_code == 0
+    file_types = "*.svs"
+    files_all = utils.misc.grab_files_from_dir(
+        input_path=str(pathlib.Path(__file__).parent), file_types=file_types,
+    )
+    save_tiles_result = runner.invoke(
+        cli.main,
+        [
+            "save-tiles",
+            "--wsi_input",
+            files_all[0],
+            "--file_types",
+            '"*.ndpi, *.svs"',
+            "--workers",
+            "2",
+            "--tile_objective_value",
+            "5",
+        ],
+    )
+
+    assert save_tiles_result.exit_code == 0
+

--- a/tests/test_tiatoolbox.py
+++ b/tests/test_tiatoolbox.py
@@ -235,6 +235,41 @@ def test_save_tiles(_response_ndpi, _response_svs):
     shutil.rmtree(pathlib.Path(__file__).parent.joinpath("tiles_save_tiles"))
 
 
+def test_save_tiles_unwrap(_response_svs):
+    file_types = ("*.svs", "*.mrxs")
+    files_all = utils.misc.grab_files_from_dir(
+        input_path=str(pathlib.Path(__file__).parent), file_types=file_types,
+    )
+    unwrapped_save_tiles = save_tiles.__closure__[0].cell_contents
+    unwrapped_save_tiles(
+        input_path=files_all[0],
+        tile_objective_value=5,
+        output_dir=str(pathlib.Path(__file__).parent.joinpath("tiles_save_tiles")),
+        verbose=True,
+    )
+    assert (
+        pathlib.Path(__file__)
+            .parent.joinpath("tiles_save_tiles")
+            .joinpath("CMU-1-Small-Region.svs")
+            .joinpath("Output.csv")
+            .exists()
+    )
+    assert (
+        pathlib.Path(__file__)
+            .parent.joinpath("tiles_save_tiles")
+            .joinpath("CMU-1-Small-Region.svs")
+            .joinpath("slide_thumbnail.jpg")
+            .exists()
+    )
+    assert (
+        pathlib.Path(__file__)
+            .parent.joinpath("tiles_save_tiles")
+            .joinpath("CMU-1-Small-Region.svs")
+            .joinpath("Tile_5_0_0.jpg")
+            .exists()
+    )
+
+
 # -------------------------------------------------------------------------------------
 # Command Line Interface
 # -------------------------------------------------------------------------------------

--- a/tests/test_tiatoolbox.py
+++ b/tests/test_tiatoolbox.py
@@ -75,6 +75,11 @@ def test_slide_info(_response_ndpi, _response_svs):
     for slide_param in slide_params:
         utils.misc.save_yaml(slide_param, slide_param["file_name"] + ".yaml")
 
+    unwrapped_slide_info = slide_info.__closure__[0].cell_contents
+    utils.misc.save_yaml(
+        unwrapped_slide_info(input_path=files_all[0], verbose=True),
+        "test.yaml")
+
 
 def test_wsireader_slide_info(_response_svs):
     """pytest for slide_info in WSIReader class as a python function"""

--- a/tests/test_tiatoolbox.py
+++ b/tests/test_tiatoolbox.py
@@ -289,11 +289,9 @@ def test_exception_tests():
         )
 
 
-
 # -------------------------------------------------------------------------------------
 # Command Line Interface
 # -------------------------------------------------------------------------------------
-
 
 def test_command_line_help_interface():
     """Test the CLI help"""
@@ -325,6 +323,29 @@ def test_command_line_slide_info(_response_ndpi, _response_svs):
             '"*.ndpi, *.svs"',
             "--workers",
             "2",
+            "--mode",
+            "save",
+        ],
+    )
+
+    assert slide_info_result.exit_code == 0
+
+    file_types = "*.svs"
+    files_all = utils.misc.grab_files_from_dir(
+        input_path=str(pathlib.Path(__file__).parent), file_types=file_types,
+    )
+    slide_info_result = runner.invoke(
+        cli.main,
+        [
+            "slide-info",
+            "--wsi_input",
+            files_all[0],
+            "--file_types",
+            '"*.ndpi, *.svs"',
+            "--workers",
+            "2",
+            "--mode",
+            "save",
         ],
     )
 
@@ -361,7 +382,7 @@ def test_command_line_read_region(_response_ndpi):
 def test_command_line_slide_thumbnail(_response_ndpi):
     """Test the Slide Thumbnail CLI."""
     runner = CliRunner()
-    read_region_result = runner.invoke(
+    slide_thumb_result = runner.invoke(
         cli.main,
         [
             "slide-thumbnail",
@@ -374,7 +395,7 @@ def test_command_line_slide_thumbnail(_response_ndpi):
         ],
     )
 
-    assert read_region_result.exit_code == 0
+    assert slide_thumb_result.exit_code == 0
     assert pathlib.Path(__file__).parent.joinpath("slide_thumb.jpg").is_file()
 
 

--- a/tests/test_tiatoolbox.py
+++ b/tests/test_tiatoolbox.py
@@ -73,8 +73,8 @@ def test_slide_info(_response_ndpi, _response_svs):
     )
     slide_params = slide_info(input_path=files_all, workers=2, verbose=True)
 
-    for i in range(len(slide_params)):
-        utils.misc.save_yaml(slide_params[i], slide_params[i].file_name + ".yaml")
+    for _, slide_param in enumerate(slide_params):
+        utils.misc.save_yaml(slide_param.as_dict(), slide_param.file_name + ".yaml")
 
     unwrapped_slide_info = slide_info.__closure__[0].cell_contents
     utils.misc.save_yaml(
@@ -91,7 +91,7 @@ def test_wsireader_slide_info(_response_svs):
     input_dir, file_name, ext = utils.misc.split_path_name_ext(str(files_all[0]))
     wsi_obj = wsireader.OpenSlideWSIReader(input_dir, file_name + ext)
     slide_param = wsi_obj.slide_info
-    utils.misc.save_yaml(slide_param, slide_param.file_name + ".yaml")
+    utils.misc.save_yaml(slide_param.as_dict(), slide_param.file_name + ".yaml")
 
 
 def test_wsireader_read_region(_response_svs):

--- a/tests/test_tiatoolbox.py
+++ b/tests/test_tiatoolbox.py
@@ -127,7 +127,7 @@ def test_wsireader_slide_thumbnail(_response_svs):
 def test_imresize():
     """pytest for imresize"""
     img = np.zeros((2000, 2000, 3))
-    resized_img = utils.misc.imresize(img, 0.5)
+    resized_img = utils.transforms.imresize(img, 0.5)
     assert resized_img.shape == (1000, 1000, 3)
 
 

--- a/tests/test_tiatoolbox.py
+++ b/tests/test_tiatoolbox.py
@@ -70,7 +70,7 @@ def test_slide_info(_response_ndpi, _response_svs):
     files_all = utils.misc.grab_files_from_dir(
         input_path=str(pathlib.Path(__file__).parent), file_types=file_types,
     )
-    slide_params = slide_info(input_path=files_all, workers=2)
+    slide_params = slide_info(input_path=files_all, workers=2, verbose=True)
 
     for slide_param in slide_params:
         utils.misc.save_yaml(slide_param, slide_param["file_name"] + ".yaml")

--- a/tests/test_tiatoolbox.py
+++ b/tests/test_tiatoolbox.py
@@ -73,8 +73,8 @@ def test_slide_info(_response_ndpi, _response_svs):
     )
     slide_params = slide_info(input_path=files_all, workers=2, verbose=True)
 
-    for slide_param in slide_params:
-        utils.misc.save_yaml(slide_param, slide_param["file_name"] + ".yaml")
+    for i in range(len(slide_params)):
+        utils.misc.save_yaml(slide_params[i], slide_params[i].file_name + ".yaml")
 
     unwrapped_slide_info = slide_info.__closure__[0].cell_contents
     utils.misc.save_yaml(
@@ -91,7 +91,7 @@ def test_wsireader_slide_info(_response_svs):
     input_dir, file_name, ext = utils.misc.split_path_name_ext(str(files_all[0]))
     wsi_obj = wsireader.OpenSlideWSIReader(input_dir, file_name + ext)
     slide_param = wsi_obj.slide_info
-    utils.misc.save_yaml(slide_param, slide_param["file_name"] + ".yaml")
+    utils.misc.save_yaml(slide_param, slide_param.file_name + ".yaml")
 
 
 def test_wsireader_read_region(_response_svs):

--- a/tests/test_tiatoolbox.py
+++ b/tests/test_tiatoolbox.py
@@ -147,7 +147,7 @@ def test_wsireader_save_tiles(_response_svs):
         output_dir=str(pathlib.Path(__file__).parent.joinpath("tiles")),
         tile_objective_value=5,
     )
-    wsi_obj.save_tiles()
+    wsi_obj.save_tiles(verbose=True)
     assert (
         pathlib.Path(__file__)
         .parent.joinpath("tiles")

--- a/tests/test_tiatoolbox.py
+++ b/tests/test_tiatoolbox.py
@@ -183,6 +183,7 @@ def test_save_tiles(_response_ndpi, _response_svs):
         workers=2,
         tile_objective_value=5,
         output_dir=str(pathlib.Path(__file__).parent.joinpath("tiles_save_tiles")),
+        verbose=True,
     )
     assert (
         pathlib.Path(__file__)

--- a/tiatoolbox/cli.py
+++ b/tiatoolbox/cli.py
@@ -53,6 +53,7 @@ def main():
 @click.option(
     "--verbose",
     type=bool,
+    default=True,
     help="Print output, default=True",
 )
 def slide_info(wsi_input, output_dir, file_types, mode, workers=None, verbose=True):
@@ -222,6 +223,12 @@ def slide_thumbnail(wsi_input, output_path, mode):
     help="num of cpu cores to use for multiprocessing, "
     "default=multiprocessing.cpu_count()",
 )
+@click.option(
+    "--verbose",
+    type=bool,
+    default=True,
+    help="Print output, default=True",
+)
 def save_tiles(
     wsi_input,
     output_dir,
@@ -230,6 +237,7 @@ def save_tiles(
     tile_read_size_w,
     tile_read_size_h,
     workers=None,
+    verbose=True,
 ):
     """Displays or saves WSI metadata"""
     file_types = tuple(file_types.split(", "))
@@ -252,6 +260,7 @@ def save_tiles(
         tile_objective_value=tile_objective_value,
         tile_read_size_w=tile_read_size_w,
         tile_read_size_h=tile_read_size_h,
+        verbose=verbose,
         workers=workers,
     )
 

--- a/tiatoolbox/cli.py
+++ b/tiatoolbox/cli.py
@@ -2,6 +2,7 @@
 from tiatoolbox import __version__
 from tiatoolbox import dataloader
 from tiatoolbox import utils
+from tiatoolbox.utils.exceptions import FileNotSupported
 
 import sys
 import click
@@ -125,7 +126,7 @@ def slide_info(wsi_input, output_dir, file_types, mode, workers=None, verbose=Tr
 )
 def read_region(wsi_input, region, level, output_path, mode):
     """Reads a region in an whole slide image as specified"""
-    if all(region):
+    if not region:
         region = [0, 0, 2000, 2000]
 
     input_dir, file_name, file_type = utils.misc.split_path_name_ext(
@@ -190,7 +191,7 @@ def slide_thumbnail(wsi_input, output_path, mode):
         if mode == "save":
             utils.misc.imwrite(output_path, slide_thumb)
     else:
-        raise Exception("File Type not supported!")
+        raise FileNotSupported
 
 
 @main.command()
@@ -250,7 +251,7 @@ def save_tiles(
             wsi_input,
         ]
     else:
-        raise ValueError("wsi_input path is not valid")
+        raise FileNotFoundError
 
     print(files_all)
 

--- a/tiatoolbox/cli.py
+++ b/tiatoolbox/cli.py
@@ -122,19 +122,30 @@ def read_region(wsi_input, region, level, output_path, mode):
     if all(region):
         region = [0, 0, 2000, 2000]
 
-    input_dir, file_name, ext = utils.misc.split_path_name_ext(full_path=wsi_input)
+    input_dir, file_name, file_type = utils.misc.split_path_name_ext(
+        full_path=wsi_input
+    )
     if output_path is None and mode == "save":
         output_path = str(pathlib.Path(input_dir).joinpath("../im_region.jpg"))
-    wsi_obj = dataloader.wsireader.WSIReader(
-        input_dir=input_dir, file_name=file_name + ext
-    )
-    im_region = wsi_obj.read_region(region[0], region[1], region[2], region[3], level)
-    if mode == "show":
-        im_region = Image.fromarray(im_region)
-        im_region.show()
 
-    if mode == "save":
-        utils.misc.imwrite(output_path, im_region)
+    wsi_obj = None
+    if file_type in (".svs", ".ndpi", ".mrxs"):
+        wsi_obj = dataloader.wsireader.OpenSlideWSIReader(
+            input_dir=input_dir, file_name=file_name + file_type
+        )
+
+    if wsi_obj is not None:
+        im_region = wsi_obj.read_region(
+            region[0], region[1], region[2], region[3], level
+        )
+        if mode == "show":
+            im_region = Image.fromarray(im_region)
+            im_region.show()
+
+        if mode == "save":
+            utils.misc.imwrite(output_path, im_region)
+    else:
+        raise Exception("File Type not supported!")
 
 
 @main.command()
@@ -153,21 +164,27 @@ def read_region(wsi_input, region, level, output_path, mode):
 def slide_thumbnail(wsi_input, output_path, mode):
     """Reads whole slide image thumbnail"""
 
-    input_dir, file_name, ext = utils.misc.split_path_name_ext(full_path=wsi_input)
+    input_dir, file_name, file_type = utils.misc.split_path_name_ext(
+        full_path=wsi_input
+    )
     if output_path is None and mode == "save":
         output_path = str(pathlib.Path(input_dir).joinpath("../im_region.jpg"))
-    wsi_obj = dataloader.wsireader.WSIReader(
-        input_dir=input_dir, file_name=file_name + ext
-    )
+    wsi_obj = None
+    if file_type in (".svs", ".ndpi", ".mrxs"):
+        wsi_obj = dataloader.wsireader.OpenSlideWSIReader(
+            input_dir=input_dir, file_name=file_name + file_type
+        )
+    if wsi_obj is not None:
+        slide_thumb = wsi_obj.slide_thumbnail()
 
-    slide_thumb = wsi_obj.slide_thumbnail()
+        if mode == "show":
+            im_region = Image.fromarray(slide_thumb)
+            im_region.show()
 
-    if mode == "show":
-        im_region = Image.fromarray(slide_thumb)
-        im_region.show()
-
-    if mode == "save":
-        utils.misc.imwrite(output_path, slide_thumb)
+        if mode == "save":
+            utils.misc.imwrite(output_path, slide_thumb)
+    else:
+        raise Exception("File Type not supported!")
 
 
 @main.command()

--- a/tiatoolbox/cli.py
+++ b/tiatoolbox/cli.py
@@ -86,15 +86,15 @@ def slide_info(wsi_input, output_dir, file_types, mode, workers=None, verbose=Tr
     )
 
     if mode == "show":
-        for i in range(len(slide_params)):
-            print(slide_params[i].as_dict())
+        for _, slide_param in enumerate(slide_params):
+            print(slide_param.as_dict())
 
     if mode == "save":
         output_dir.mkdir(parents=True, exist_ok=True)
-        for i in range(len(slide_params)):
+        for _, slide_param in enumerate(slide_params):
             utils.misc.save_yaml(
-                slide_params[i].as_dict(),
-                pathlib.Path(output_dir).joinpath(slide_params[i].file_name + ".yaml"),
+                slide_param.as_dict(),
+                pathlib.Path(output_dir).joinpath(slide_param.file_name + ".yaml"),
             )
         print("Meta files saved at " + str(output_dir))
 

--- a/tiatoolbox/cli.py
+++ b/tiatoolbox/cli.py
@@ -50,7 +50,12 @@ def main():
     help="num of cpu cores to use for multiprocessing, "
     "default=multiprocessing.cpu_count()",
 )
-def slide_info(wsi_input, output_dir, file_types, mode, workers=None):
+@click.option(
+    "--verbose",
+    type=bool,
+    help="Print output, default=True",
+)
+def slide_info(wsi_input, output_dir, file_types, mode, workers=None, verbose=True):
     """Displays or saves WSI metadata"""
     file_types = tuple(file_types.split(", "))
 
@@ -75,7 +80,7 @@ def slide_info(wsi_input, output_dir, file_types, mode, workers=None):
     print(files_all)
 
     slide_params = dataloader.slide_info.slide_info(
-        input_path=files_all, workers=workers,
+        input_path=files_all, workers=workers, verbose=verbose
     )
 
     if mode == "show":

--- a/tiatoolbox/cli.py
+++ b/tiatoolbox/cli.py
@@ -77,7 +77,7 @@ def slide_info(wsi_input, output_dir, file_types, mode, workers=None, verbose=Tr
             input_dir, _, _ = utils.misc.split_path_name_ext(wsi_input)
             output_dir = pathlib.Path(input_dir).joinpath("..").joinpath("meta")
     else:
-        raise ValueError("wsi_input path is not valid")
+        raise FileNotFoundError
 
     print(files_all)
 
@@ -152,7 +152,7 @@ def read_region(wsi_input, region, level, output_path, mode):
         if mode == "save":
             utils.misc.imwrite(output_path, im_region)
     else:
-        raise Exception("File Type not supported!")
+        raise FileNotSupported
 
 
 @main.command()

--- a/tiatoolbox/cli.py
+++ b/tiatoolbox/cli.py
@@ -86,15 +86,15 @@ def slide_info(wsi_input, output_dir, file_types, mode, workers=None, verbose=Tr
     )
 
     if mode == "show":
-        for slide_param in slide_params:
-            print(slide_param.as_dict())
+        for i in range(len(slide_params)):
+            print(slide_params[i].as_dict())
 
     if mode == "save":
         output_dir.mkdir(parents=True, exist_ok=True)
-        for slide_param in slide_params:
+        for i in range(len(slide_params)):
             utils.misc.save_yaml(
-                slide_param.as_dict(),
-                pathlib.Path(output_dir).joinpath(slide_param["file_name"] + ".yaml"),
+                slide_params[i].as_dict(),
+                pathlib.Path(output_dir).joinpath(slide_params[i].file_name + ".yaml"),
             )
         print("Meta files saved at " + str(output_dir))
 

--- a/tiatoolbox/cli.py
+++ b/tiatoolbox/cli.py
@@ -87,13 +87,13 @@ def slide_info(wsi_input, output_dir, file_types, mode, workers=None, verbose=Tr
 
     if mode == "show":
         for slide_param in slide_params:
-            print(slide_param)
+            print(slide_param.as_dict())
 
     if mode == "save":
         output_dir.mkdir(parents=True, exist_ok=True)
         for slide_param in slide_params:
             utils.misc.save_yaml(
-                slide_param,
+                slide_param.as_dict(),
                 pathlib.Path(output_dir).joinpath(slide_param["file_name"] + ".yaml"),
             )
         print("Meta files saved at " + str(output_dir))

--- a/tiatoolbox/dataloader/save_tiles.py
+++ b/tiatoolbox/dataloader/save_tiles.py
@@ -11,6 +11,7 @@ def save_tiles(
     tile_objective_value=20,
     tile_read_size_w=5000,
     tile_read_size_h=5000,
+    verbose=True,
 ):
     """Save image tiles for whole slide image. Default file format for tiles is jpg.
     Multiprocessing decorator runs this function in parallel using the number of
@@ -23,6 +24,7 @@ def save_tiles(
                 default=20
         tile_read_size_w (int): tile width, default=5000
         tile_read_size_h (int): tile height, default=5000
+        verbose (bool): Print output, default=True
         workers (int): num of cpu cores to use for multiprocessing
 
     Returns:
@@ -43,8 +45,8 @@ def save_tiles(
     """
 
     input_dir, file_name, ext = misc.split_path_name_ext(input_path)
-
-    print(file_name + ext, flush=True)
+    if verbose:
+        print(file_name + ext, flush=True)
 
     if ext in (".svs", ".ndpi", ".mrxs"):
         wsi_reader = wsireader.OpenSlideWSIReader(

--- a/tiatoolbox/dataloader/save_tiles.py
+++ b/tiatoolbox/dataloader/save_tiles.py
@@ -2,6 +2,7 @@
 from tiatoolbox.dataloader import wsireader
 from tiatoolbox.decorators.multiproc import TIAMultiProcess
 from tiatoolbox.utils import misc
+from tiatoolbox.utils.exceptions import FileNotSupported
 
 
 @TIAMultiProcess(iter_on="input_path")
@@ -59,4 +60,4 @@ def save_tiles(
         )
         wsi_reader.save_tiles(verbose=verbose)
     else:
-        raise Exception("File type not supported")
+        raise FileNotSupported

--- a/tiatoolbox/dataloader/save_tiles.py
+++ b/tiatoolbox/dataloader/save_tiles.py
@@ -57,6 +57,6 @@ def save_tiles(
             tile_read_size_w=tile_read_size_w,
             tile_read_size_h=tile_read_size_h,
         )
-        wsi_reader.save_tiles()
+        wsi_reader.save_tiles(verbose=verbose)
     else:
         raise Exception("File type not supported")

--- a/tiatoolbox/dataloader/save_tiles.py
+++ b/tiatoolbox/dataloader/save_tiles.py
@@ -47,7 +47,7 @@ def save_tiles(
     print(file_name + ext, flush=True)
 
     if ext in (".svs", ".ndpi", ".mrxs"):
-        wsi_reader = wsireader.WSIReader(
+        wsi_reader = wsireader.OpenSlideWSIReader(
             input_dir=input_dir,
             file_name=file_name + ext,
             output_dir=output_dir,

--- a/tiatoolbox/dataloader/slide_info.py
+++ b/tiatoolbox/dataloader/slide_info.py
@@ -27,9 +27,9 @@ def slide_info(input_path, output_dir=None, verbose=True):
         ...     file_types=file_types)
         >>> slide_params = slide_info(input_path=files_all, workers=2)
         >>> for slide_param in slide_params:
-        ...        utils.misc.save_yaml(slide_param,
-        ...             slide_param["file_name"] + ".yaml")
-        ...        print(slide_param)
+        ...        utils.misc.save_yaml(slide_param.as_dict(),
+        ...             slide_param.file_name + ".yaml")
+        ...        print(slide_param.as_dict())
 
     """
 
@@ -45,7 +45,7 @@ def slide_info(input_path, output_dir=None, verbose=True):
         )
         info = wsi_reader.slide_info
         if verbose:
-            print(info)
+            print(info.as_dict())
     else:
         raise FileNotSupported(file_type + " file format is not supported.")
 

--- a/tiatoolbox/dataloader/slide_info.py
+++ b/tiatoolbox/dataloader/slide_info.py
@@ -6,7 +6,7 @@ import os
 
 
 @TIAMultiProcess(iter_on="input_path")
-def slide_info(input_path, output_dir=None):
+def slide_info(input_path, output_dir=None, verbose=1):
     """Single file run to output or save WSI meta data.
 
     Multiprocessing uses this function to run slide_info in parallel
@@ -34,14 +34,15 @@ def slide_info(input_path, output_dir=None):
 
     input_dir, file_name = os.path.split(input_path)
 
-    print(file_name, flush=True)
+    if verbose:
+        print(file_name, flush=True)
     _, file_type = os.path.splitext(file_name)
 
     if file_type in (".svs", ".ndpi", ".mrxs"):
-        wsi_reader = wsireader.WSIReader(
+        wsi_reader = wsireader.OpenSlideWSIReader(
             input_dir=input_dir, file_name=file_name, output_dir=output_dir
         )
-        info = wsi_reader.slide_info()
+        info = wsi_reader.slide_info
     else:
         print("File type not supported")
         info = None

--- a/tiatoolbox/dataloader/slide_info.py
+++ b/tiatoolbox/dataloader/slide_info.py
@@ -5,15 +5,18 @@ from tiatoolbox.decorators.multiproc import TIAMultiProcess
 import os
 
 
-def slide_info_single(input_path, output_dir=None, verbose=True):
-    """Wrapper for multi core slide_info
+@TIAMultiProcess(iter_on="input_path")
+def slide_info(input_path, output_dir=None, verbose=True):
+    """Returns WSI meta data. Multiprocessing decorator runs this function in parallel.
+
     Args:
         input_path (str): Path to whole slide image
         output_dir (str): Path to output directory to save the output
         verbose(bool): Print output, default=True
+        workers (int): num of cpu cores to use for multiprocessing
 
     Returns:
-        dict: dictionary with Whole Slide meta information
+        list: list of dictionary Whole Slide meta information
 
     Examples:
         >>> from tiatoolbox.dataloader.slide_info import slide_info
@@ -21,13 +24,14 @@ def slide_info_single(input_path, output_dir=None, verbose=True):
         >>> file_types = ("*.ndpi", "*.svs", "*.mrxs")
         >>> files_all = utils.misc.grab_files_from_dir(input_path,
         ...     file_types=file_types)
-        >>> for i in range(len(files_all)):
-        ...     slide_param = slide_info_single(input_path=files_all[i])
-        ...     utils.misc.save_yaml(slide_param,
+        >>> slide_params = slide_info(input_path=files_all, workers=2)
+        >>> for slide_param in slide_params:
+        ...        utils.misc.save_yaml(slide_param,
         ...             slide_param["file_name"] + ".yaml")
         ...        print(slide_param)
 
     """
+
     input_dir, file_name = os.path.split(input_path)
 
     if verbose:
@@ -46,35 +50,3 @@ def slide_info_single(input_path, output_dir=None, verbose=True):
         info = None
 
     return info
-
-
-@TIAMultiProcess(iter_on="input_path")
-def slide_info(input_path, output_dir=None, verbose=True):
-    """Single file run to output or save WSI meta data.
-
-    Multiprocessing uses this function to run slide_info in parallel
-
-    Args:
-        input_path (str): Path to whole slide image
-        output_dir (str): Path to output directory to save the output
-        verbose(bool): Print output, default=True
-        workers (int): num of cpu cores to use for multiprocessing
-    Returns:
-        list: list of dictionary Whole Slide meta information
-
-    Examples:
-        >>> from tiatoolbox.dataloader.slide_info import slide_info
-        >>> from tiatoolbox import utils
-        >>> file_types = ("*.ndpi", "*.svs", "*.mrxs")
-        >>> files_all = utils.misc.grab_files_from_dir(input_path,
-        ...     file_types=file_types)
-        >>> slide_params = slide_info(input_path=files_all, workers=2)
-        >>> for slide_param in slide_params:
-        ...        utils.misc.save_yaml(slide_param,
-        ...             slide_param["file_name"] + ".yaml")
-        ...        print(slide_param)
-
-        """
-    return slide_info_single(
-        input_path=input_path, output_dir=output_dir, verbose=verbose
-    )

--- a/tiatoolbox/dataloader/slide_info.py
+++ b/tiatoolbox/dataloader/slide_info.py
@@ -5,6 +5,49 @@ from tiatoolbox.decorators.multiproc import TIAMultiProcess
 import os
 
 
+def slide_info_single(input_path, output_dir=None, verbose=True):
+    """Wrapper for multi core slide_info
+    Args:
+        input_path (str): Path to whole slide image
+        output_dir (str): Path to output directory to save the output
+        verbose(bool): Print output, default=True
+
+    Returns:
+        dict: dictionary with Whole Slide meta information
+
+    Examples:
+        >>> from tiatoolbox.dataloader.slide_info import slide_info
+        >>> from tiatoolbox import utils
+        >>> file_types = ("*.ndpi", "*.svs", "*.mrxs")
+        >>> files_all = utils.misc.grab_files_from_dir(input_path,
+        ...     file_types=file_types)
+        >>> for i in range(len(files_all)):
+        ...     slide_param = slide_info_single(input_path=files_all[i])
+        ...     utils.misc.save_yaml(slide_param,
+        ...             slide_param["file_name"] + ".yaml")
+        ...        print(slide_param)
+
+    """
+    input_dir, file_name = os.path.split(input_path)
+
+    if verbose:
+        print(file_name, flush=True)
+    _, file_type = os.path.splitext(file_name)
+
+    if file_type in (".svs", ".ndpi", ".mrxs"):
+        wsi_reader = wsireader.OpenSlideWSIReader(
+            input_dir=input_dir, file_name=file_name, output_dir=output_dir
+        )
+        info = wsi_reader.slide_info
+        if verbose:
+            print(info)
+    else:
+        print("File type not supported")
+        info = None
+
+    return info
+
+
 @TIAMultiProcess(iter_on="input_path")
 def slide_info(input_path, output_dir=None, verbose=True):
     """Single file run to output or save WSI meta data.
@@ -31,23 +74,7 @@ def slide_info(input_path, output_dir=None, verbose=True):
         ...             slide_param["file_name"] + ".yaml")
         ...        print(slide_param)
 
-    """
-
-    input_dir, file_name = os.path.split(input_path)
-
-    if verbose:
-        print(file_name, flush=True)
-    _, file_type = os.path.splitext(file_name)
-
-    if file_type in (".svs", ".ndpi", ".mrxs"):
-        wsi_reader = wsireader.OpenSlideWSIReader(
-            input_dir=input_dir, file_name=file_name, output_dir=output_dir
-        )
-        info = wsi_reader.slide_info
-        if verbose:
-            print(info)
-    else:
-        print("File type not supported")
-        info = None
-
-    return info
+        """
+    return slide_info_single(
+        input_path=input_path, output_dir=output_dir, verbose=verbose
+    )

--- a/tiatoolbox/dataloader/slide_info.py
+++ b/tiatoolbox/dataloader/slide_info.py
@@ -1,6 +1,7 @@
 """Get Slide Meta Data information"""
 from tiatoolbox.dataloader import wsireader
 from tiatoolbox.decorators.multiproc import TIAMultiProcess
+from tiatoolbox.utils.exceptions import FileNotSupported
 
 import os
 
@@ -46,7 +47,6 @@ def slide_info(input_path, output_dir=None, verbose=True):
         if verbose:
             print(info)
     else:
-        print("File type not supported")
-        info = None
+        raise FileNotSupported
 
     return info

--- a/tiatoolbox/dataloader/slide_info.py
+++ b/tiatoolbox/dataloader/slide_info.py
@@ -6,7 +6,7 @@ import os
 
 
 @TIAMultiProcess(iter_on="input_path")
-def slide_info(input_path, output_dir=None, verbose=1):
+def slide_info(input_path, output_dir=None, verbose=True):
     """Single file run to output or save WSI meta data.
 
     Multiprocessing uses this function to run slide_info in parallel
@@ -14,6 +14,7 @@ def slide_info(input_path, output_dir=None, verbose=1):
     Args:
         input_path (str): Path to whole slide image
         output_dir (str): Path to output directory to save the output
+        verbose(bool): Print output, default=True
         workers (int): num of cpu cores to use for multiprocessing
     Returns:
         list: list of dictionary Whole Slide meta information
@@ -43,6 +44,8 @@ def slide_info(input_path, output_dir=None, verbose=1):
             input_dir=input_dir, file_name=file_name, output_dir=output_dir
         )
         info = wsi_reader.slide_info
+        if verbose:
+            print(info)
     else:
         print("File type not supported")
         info = None

--- a/tiatoolbox/dataloader/slide_info.py
+++ b/tiatoolbox/dataloader/slide_info.py
@@ -13,7 +13,7 @@ def slide_info(input_path, output_dir=None, verbose=True):
     Args:
         input_path (str): Path to whole slide image
         output_dir (str): Path to output directory to save the output
-        verbose(bool): Print output, default=True
+        verbose (bool): Print output, default=True
         workers (int): num of cpu cores to use for multiprocessing
 
     Returns:
@@ -47,6 +47,6 @@ def slide_info(input_path, output_dir=None, verbose=True):
         if verbose:
             print(info)
     else:
-        raise FileNotSupported
+        raise FileNotSupported(file_type + " file format is not supported.")
 
     return info

--- a/tiatoolbox/dataloader/wsimeta.py
+++ b/tiatoolbox/dataloader/wsimeta.py
@@ -20,17 +20,17 @@ class WSIMeta:
                  ):
         self.input_dir = input_dir
         self.file_name = file_name
-        self.objective_power = objective_power,
-        self.slide_dimension = slide_dimension,
-        self.rescale = rescale,
-        self.tile_objective_value = tile_objective_value,
-        self.tile_read_size = tile_read_size,
-        self.level_count = level_count,
-        self.level_dimensions = level_dimensions,
-        self.level_downsamples = level_downsamples,
-        self.vendor = vendor,
-        self.mpp_x = mpp_x,
-        self.mpp_y = mpp_y,
+        self.objective_power = objective_power
+        self.slide_dimension = slide_dimension
+        self.rescale = rescale
+        self.tile_objective_value = tile_objective_value
+        self.tile_read_size = tile_read_size
+        self.level_count = level_count
+        self.level_dimensions = level_dimensions
+        self.level_downsamples = level_downsamples
+        self.vendor = vendor
+        self.mpp_x = mpp_x
+        self.mpp_y = mpp_y
 
     def as_dict(self):
         """

--- a/tiatoolbox/dataloader/wsimeta.py
+++ b/tiatoolbox/dataloader/wsimeta.py
@@ -1,0 +1,61 @@
+"""WSIMeta to save metadata information for WSIs"""
+
+
+class WSIMeta:
+    """Whole slide image meta data class"""
+    def __init__(self,
+                 input_dir,
+                 file_name,
+                 objective_power=None,
+                 slide_dimension=None,
+                 rescale=None,
+                 tile_objective_value=None,
+                 tile_read_size=None,
+                 level_count=None,
+                 level_dimensions=None,
+                 level_downsamples=None,
+                 vendor=None,
+                 mpp_x=None,
+                 mpp_y=None,
+                 ):
+        self.input_dir = input_dir
+        self.file_name = file_name
+        self.objective_power = objective_power,
+        self.slide_dimension = slide_dimension,
+        self.rescale = rescale,
+        self.tile_objective_value = tile_objective_value,
+        self.tile_read_size = tile_read_size,
+        self.level_count = level_count,
+        self.level_dimensions = level_dimensions,
+        self.level_downsamples = level_downsamples,
+        self.vendor = vendor,
+        self.mpp_x = mpp_x,
+        self.mpp_y = mpp_y,
+
+    def as_dict(self):
+        """
+        Converts WSIMeta to dictionary to assist print and save in various formats
+
+        Args:
+            self (WSIMeta):
+
+        Returns:
+            dict: whole slide image meta data as dictionary
+
+        """
+        param = {
+            "input_dir": self.input_dir,
+            "objective_power": self.objective_power,
+            "slide_dimension": self.slide_dimension,
+            "rescale": self.rescale,
+            "tile_objective_value": self.tile_objective_value,
+            "tile_read_size": self.tile_read_size,
+            "level_count": self.level_count,
+            "level_dimensions": self.level_dimensions,
+            "level_downsamples": self.level_downsamples,
+            "vendor": self.vendor,
+            "mpp_x": self.mpp_x,
+            "mpp_y": self.mpp_y,
+            "file_name": self.file_name,
+        }
+        return param

--- a/tiatoolbox/dataloader/wsireader.py
+++ b/tiatoolbox/dataloader/wsireader.py
@@ -254,7 +254,7 @@ class WSIReader:
 
 
 class OpenSlideWSIReader(WSIReader):
-    """Class for handling OpenSlide supported whole-slide images.
+    """Class for reading OpenSlide supported whole-slide images.
 
     Attributes:
         openslide_obj (:obj:`openslide.OpenSlide`)

--- a/tiatoolbox/dataloader/wsireader.py
+++ b/tiatoolbox/dataloader/wsireader.py
@@ -52,7 +52,7 @@ class WSIReader:
         self.tile_read_size = np.array([tile_read_size_w, tile_read_size_h])
         self.slide_info = None
 
-    def __slide_info__(self):
+    def __slide_info(self):
         """WSI meta data reader
 
         Args:
@@ -283,7 +283,7 @@ class OpenSlideWSIReader(WSIReader):
         self.openslide_obj = openslide.OpenSlide(
             filename=str(pathlib.Path(self.input_dir, self.file_name))
         )
-        self.slide_info = self.__slide_info__()
+        self.slide_info = self.__slide_info()
 
     def read_region(self, start_w, start_h, end_w, end_h, level=0):
         """Read a region in whole slide image
@@ -319,7 +319,7 @@ class OpenSlideWSIReader(WSIReader):
         im_region = transforms.background_composite(image=im_region)
         return im_region
 
-    def __slide_info__(self):
+    def __slide_info(self):
         """WSI meta data reader
 
         Args:
@@ -332,7 +332,7 @@ class OpenSlideWSIReader(WSIReader):
             >>> from tiatoolbox.dataloader import wsireader
             >>> wsi_obj = wsireader.WSIReader(input_dir="./",
             ...     file_name="CMU-1.ndpi")
-            >>> slide_param = wsi_obj.__slide_info__()
+            >>> slide_param = wsi_obj.__slide_info()
 
         """
         input_dir = self.input_dir

--- a/tiatoolbox/dataloader/wsireader.py
+++ b/tiatoolbox/dataloader/wsireader.py
@@ -1,6 +1,5 @@
 """WSIReader for WSI reading or extracting metadata information from WSIs"""
-from tiatoolbox.utils import misc
-from tiatoolbox.utils.transforms import background_composite
+from tiatoolbox.utils import misc, transforms
 
 import pathlib
 import numpy as np
@@ -116,6 +115,7 @@ class WSIReader:
         Args:
             self (WSIReader):
             tile_format (str): file format to save image tiles, default=".jpg"
+            verbose (bool): Print output, default=True
 
         Returns:
             saves tiles in the output directory output_dir
@@ -202,7 +202,7 @@ class WSIReader:
 
                 # Rescale to the correct objective value
                 if rescale != 1:
-                    im = misc.imresize(im, rescale)
+                    im = transforms.imresize(im, rescale)
 
                 img_save_name = (
                     "_".join(
@@ -316,7 +316,7 @@ class OpenSlideWSIReader(WSIReader):
         im_region = openslide_obj.read_region(
             [start_w, start_h], level, [end_w - start_w, end_h - start_h]
         )
-        im_region = background_composite(image=im_region)
+        im_region = transforms.background_composite(image=im_region)
         return im_region
 
     def __slide_info__(self):

--- a/tiatoolbox/dataloader/wsireader.py
+++ b/tiatoolbox/dataloader/wsireader.py
@@ -16,15 +16,9 @@ class WSIReader:
         input_dir (pathlib.Path): input path to WSI directory
         file_name (str): file name of the WSI
         output_dir (pathlib.Path): output directory to save the output
-        openslide_obj (:obj:`openslide.OpenSlide`)
         tile_objective_value (int): objective value at which tile is generated
         tile_read_size (int): [tile width, tile height]
-        objective_power (int): objective value at which whole slide image is scanned
-        level_count (int): The number of pyramid levels in the slide
-        level_dimensions (int): A list of `(width, height)` tuples, one for each level
-            of the slide
-        level_downsamples (int): A list of down sample factors for each level
-            of the slide
+        slide_info (dict): Whole slide image slide information
 
     """
 
@@ -55,19 +49,11 @@ class WSIReader:
         if output_dir is not None:
             self.output_dir = pathlib.Path(output_dir, self.file_name)
 
-        self.openslide_obj = openslide.OpenSlide(
-            filename=str(pathlib.Path(self.input_dir, self.file_name))
-        )
         self.tile_objective_value = np.int(tile_objective_value)  # Tile magnification
         self.tile_read_size = np.array([tile_read_size_w, tile_read_size_h])
-        self.objective_power = np.int(
-            self.openslide_obj.properties[openslide.PROPERTY_NAME_OBJECTIVE_POWER]
-        )  # magnification at which slide is scanned, this is magnification at level 0
-        self.level_count = self.openslide_obj.level_count
-        self.level_dimensions = self.openslide_obj.level_dimensions
-        self.level_downsamples = self.openslide_obj.level_downsamples
+        self.slide_info = None
 
-    def slide_info(self):
+    def __slide_info__(self):
         """WSI meta data reader
 
         Args:
@@ -76,43 +62,23 @@ class WSIReader:
         Returns:
             dict: dictionary containing meta information
 
-        Examples:
-            >>> from tiatoolbox.dataloader import wsireader
-            >>> wsi_obj = wsireader.WSIReader(input_dir="./",
-            ...     file_name="CMU-1.ndpi")
-            >>> slide_param = wsi_obj.slide_info()
-
         """
-        input_dir = self.input_dir
-        if self.objective_power == 0:
-            self.objective_power = np.int(
-                self.openslide_obj.properties[openslide.PROPERTY_NAME_OBJECTIVE_POWER]
-            )
-        objective_power = self.objective_power
-        slide_dimension = self.openslide_obj.level_dimensions[0]
-        tile_objective_value = self.tile_objective_value
-        rescale = np.int(objective_power / tile_objective_value)
-        filename = self.file_name
-        tile_read_size = self.tile_read_size
-        level_count = self.level_count
-        level_dimensions = self.level_dimensions
-        level_downsamples = self.level_downsamples
-        file_name = self.file_name
-
         param = {
-            "input_dir": input_dir,
-            "objective_power": objective_power,
-            "slide_dimension": slide_dimension,
-            "rescale": rescale,
-            "tile_objective_value": tile_objective_value,
-            "filename": filename,
-            "tile_read_size": tile_read_size.tolist(),
-            "level_count": level_count,
-            "level_dimensions": level_dimensions,
-            "level_downsamples": level_downsamples,
-            "file_name": file_name,
+            "input_dir": self.input_dir,
+            "objective_power": None,
+            "slide_dimension": None,
+            "rescale": None,
+            "tile_objective_value": None,
+            "filename": None,
+            "tile_read_size": None,
+            "level_count": None,
+            "level_dimensions": None,
+            "level_downsamples": None,
+            "vendor": None,
+            "mpp_x": None,
+            "mpp_y": None,
+            "file_name": None,
         }
-
         return param
 
     def read_region(self, start_w, start_h, end_w, end_h, level=0):
@@ -129,27 +95,11 @@ class WSIReader:
             img_array : ndarray of size MxNx3
             M=end_h-start_h, N=end_w-start_w
 
-        Examples:
-            >>> from tiatoolbox.dataloader import wsireader
-            >>> from matplotlib import pyplot as plt
-            >>> wsi_obj = wsireader.WSIReader(input_dir="./",
-            ...     file_name="CMU-1.ndpi")
-            >>> level = 0
-            >>> region = [13000, 17000, 15000, 19000]
-            >>> im_region = wsi_obj.read_region(
-            ...     region[0], region[1], region[2], region[3], level)
-            >>> plt.imshow(im_region)
-
         """
-        openslide_obj = self.openslide_obj
-        im_region = openslide_obj.read_region(
-            [start_w, start_h], level, [end_w - start_w, end_h - start_h]
-        )
-        im_region = background_composite(image=im_region)
-        return im_region
+        pass
 
     def slide_thumbnail(self):
-        """Read whole slide image thumbnail at 1.5x
+        """Read whole slide image thumbnail at 1.25x
 
         Args:
             self (WSIReader):
@@ -157,33 +107,11 @@ class WSIReader:
         Returns:
             ndarray : image array
 
-        Examples:
-            >>> from tiatoolbox.dataloader import wsireader
-            >>> wsi_obj = wsireader.WSIReader(input_dir="./",
-            ...     file_name="CMU-1.ndpi")
-            >>> slide_thumbnail = wsi_obj.slide_thumbnail()
-
         """
-        openslide_obj = self.openslide_obj
-        tile_objective_value = 20
-
-        if self.objective_power == 0:
-            self.objective_power = np.int(
-                openslide_obj.properties[openslide.PROPERTY_NAME_OBJECTIVE_POWER]
-            )
-
-        rescale = np.int(self.objective_power / tile_objective_value)
-        slide_dimension = openslide_obj.level_dimensions[0]
-        slide_dimension_20x = np.array(slide_dimension) / rescale
-        thumb = openslide_obj.get_thumbnail(
-            (int(slide_dimension_20x[0] / 16), int(slide_dimension_20x[1] / 16))
-        )
-        thumb = np.asarray(thumb)
-
-        return thumb
+        pass
 
     def save_tiles(self, tile_format=".jpg"):
-        """Generate JPEG tiles from whole slide images
+        """Generate image tiles from whole slide images.
 
         Args:
             self (WSIReader):
@@ -203,18 +131,29 @@ class WSIReader:
             >>> wsi_obj.save_tiles()
 
         """
-        openslide_obj = self.openslide_obj
         tile_objective_value = self.tile_objective_value
         tile_read_size = self.tile_read_size
 
-        if self.objective_power == 0:
-            self.objective_power = np.int(
-                openslide_obj.properties[openslide.PROPERTY_NAME_OBJECTIVE_POWER]
-            )
+        rescale = self.slide_info["objective_power"] / tile_objective_value
+        if rescale.is_integer():
+            try:
+                level = np.log2(rescale)
+                if level.is_integer():
+                    level = np.int(level)
+                    slide_dimension = self.slide_info["level_dimensions"][level]
+                    rescale = 1
+                else:
+                    raise ValueError
+            # Raise index error if desired pyramid level not embedded
+            # in level_dimensions
+            except (IndexError, ValueError):
+                level = 0
+                slide_dimension = self.slide_info["level_dimensions"][level]
+                rescale = np.int(rescale)
+        else:
+            raise ValueError("rescaling factor must be an integer.")
 
-        rescale = np.int(self.objective_power / tile_objective_value)
         tile_read_size = np.multiply(tile_read_size, rescale)
-        slide_dimension = openslide_obj.level_dimensions[0]
         slide_h = slide_dimension[1]
         slide_w = slide_dimension[0]
         tile_h = tile_read_size[0]
@@ -238,7 +177,7 @@ class WSIReader:
                     end_w = slide_w
 
                 # Read image region
-                im = self.read_region(start_w, start_h, end_w, end_h)
+                im = self.read_region(start_w, start_h, end_w, end_h, level)
                 format_str = (
                     "Tile%d:  start_w:%d, end_w:%d, "
                     "start_h:%d, end_h:%d, "
@@ -312,3 +251,153 @@ class WSIReader:
         misc.imwrite(
             output_dir.joinpath("slide_thumbnail" + tile_format), img=slide_thumb
         )
+
+
+class OpenSlideWSIReader(WSIReader):
+    """Class for handling OpenSlide supported whole-slide images.
+
+    Attributes:
+        openslide_obj (:obj:`openslide.OpenSlide`)
+
+    """
+
+    def __init__(
+        self,
+        input_dir=".",
+        file_name=None,
+        output_dir="./output",
+        tile_objective_value=20,
+        tile_read_size_w=5000,
+        tile_read_size_h=5000,
+    ):
+        """
+        file_path (string): path to single whole-slide image
+        """
+        super().__init__(
+            input_dir=input_dir,
+            file_name=file_name,
+            output_dir=output_dir,
+            tile_objective_value=tile_objective_value,
+            tile_read_size_w=tile_read_size_w,
+            tile_read_size_h=tile_read_size_h,
+        )
+        self.openslide_obj = openslide.OpenSlide(
+            filename=str(pathlib.Path(self.input_dir, self.file_name))
+        )
+        self.slide_info = self.__slide_info__()
+
+    def read_region(self, start_w, start_h, end_w, end_h, level=0):
+        """Read a region in whole slide image
+
+        Args:
+            start_w (int): starting point in x-direction (along width)
+            start_h (int): starting point in y-direction (along height)
+            end_w (int): end point in x-direction (along width)
+            end_h (int): end point in y-direction (along height)
+            level (int): pyramid level to read the image
+
+        Returns:
+            img_array : ndarray of size MxNx3
+            M=end_h-start_h, N=end_w-start_w
+
+        Examples:
+            >>> from tiatoolbox.dataloader import wsireader
+            >>> from matplotlib import pyplot as plt
+            >>> wsi_obj = wsireader.OpenSlideWSIReader(input_dir="./",
+            ...     file_name="CMU-1.ndpi")
+            >>> level = 0
+            >>> region = [13000, 17000, 15000, 19000]
+            >>> im_region = wsi_obj.read_region(
+            ...     region[0], region[1], region[2], region[3], level)
+            >>> plt.imshow(im_region)
+
+        """
+
+        openslide_obj = self.openslide_obj
+        im_region = openslide_obj.read_region(
+            [start_w, start_h], level, [end_w - start_w, end_h - start_h]
+        )
+        im_region = background_composite(image=im_region)
+        return im_region
+
+    def __slide_info__(self):
+        """WSI meta data reader
+
+        Args:
+            self (OpenSlideWSIReader):
+
+        Returns:
+            dict: dictionary containing meta information
+
+        Examples:
+            >>> from tiatoolbox.dataloader import wsireader
+            >>> wsi_obj = wsireader.WSIReader(input_dir="./",
+            ...     file_name="CMU-1.ndpi")
+            >>> slide_param = wsi_obj.__slide_info__()
+
+        """
+        input_dir = self.input_dir
+        objective_power = np.int(
+            self.openslide_obj.properties[openslide.PROPERTY_NAME_OBJECTIVE_POWER]
+        )
+        objective_power = objective_power
+        slide_dimension = self.openslide_obj.level_dimensions[0]
+        tile_objective_value = self.tile_objective_value
+        rescale = np.int(objective_power / tile_objective_value)
+        filename = self.file_name
+        tile_read_size = self.tile_read_size
+        level_count = self.openslide_obj.level_count
+        level_dimensions = self.openslide_obj.level_dimensions
+        level_downsamples = self.openslide_obj.level_downsamples
+        file_name = self.file_name
+        vendor = (self.openslide_obj.properties[openslide.PROPERTY_NAME_VENDOR],)
+        mpp_x = (self.openslide_obj.properties[openslide.PROPERTY_NAME_MPP_X],)
+        mpp_y = (self.openslide_obj.properties[openslide.PROPERTY_NAME_MPP_Y],)
+
+        param = {
+            "input_dir": input_dir,
+            "objective_power": objective_power,
+            "slide_dimension": slide_dimension,
+            "rescale": rescale,
+            "tile_objective_value": tile_objective_value,
+            "filename": filename,
+            "tile_read_size": tile_read_size.tolist(),
+            "level_count": level_count,
+            "level_dimensions": level_dimensions,
+            "level_downsamples": level_downsamples,
+            "vendor": vendor,
+            "mpp_x": mpp_x,
+            "mpp_y": mpp_y,
+            "file_name": file_name,
+        }
+
+        return param
+
+    def slide_thumbnail(self):
+        """Read whole slide image thumbnail at 1.25x
+
+        Args:
+            self (OpenSlideWSIReader):
+
+        Returns:
+            ndarray : image array
+
+        Examples:
+            >>> from tiatoolbox.dataloader import wsireader
+            >>> wsi_obj = wsireader.OpenSlideWSIReader(input_dir="./",
+            ...     file_name="CMU-1.ndpi")
+            >>> slide_thumbnail = wsi_obj.slide_thumbnail()
+
+        """
+        openslide_obj = self.openslide_obj
+        tile_objective_value = 20
+
+        rescale = np.int(self.slide_info["objective_power"] / tile_objective_value)
+        slide_dimension = self.slide_info["level_dimensions"][0]
+        slide_dimension_20x = np.array(slide_dimension) / rescale
+        thumb = openslide_obj.get_thumbnail(
+            (int(slide_dimension_20x[0] / 16), int(slide_dimension_20x[1] / 16))
+        )
+        thumb = np.asarray(thumb)
+
+        return thumb

--- a/tiatoolbox/dataloader/wsireader.py
+++ b/tiatoolbox/dataloader/wsireader.py
@@ -110,7 +110,7 @@ class WSIReader:
         """
         raise NotImplementedError
 
-    def save_tiles(self, tile_format=".jpg"):
+    def save_tiles(self, tile_format=".jpg", verbose=True):
         """Generate image tiles from whole slide images.
 
         Args:
@@ -178,25 +178,27 @@ class WSIReader:
 
                 # Read image region
                 im = self.read_region(start_w, start_h, end_w, end_h, level)
-                format_str = (
-                    "Tile%d:  start_w:%d, end_w:%d, "
-                    "start_h:%d, end_h:%d, "
-                    "width:%d, height:%d"
-                )
 
-                print(
-                    format_str
-                    % (
-                        iter_tot,
-                        start_w,
-                        end_w,
-                        start_h,
-                        end_h,
-                        end_w - start_w,
-                        end_h - start_h,
-                    ),
-                    flush=True,
-                )
+                if verbose:
+                    format_str = (
+                        "Tile%d:  start_w:%d, end_w:%d, "
+                        "start_h:%d, end_h:%d, "
+                        "width:%d, height:%d"
+                    )
+
+                    print(
+                        format_str
+                        % (
+                            iter_tot,
+                            start_w,
+                            end_w,
+                            start_h,
+                            end_h,
+                            end_w - start_w,
+                            end_h - start_h,
+                        ),
+                        flush=True,
+                    )
 
                 # Rescale to the correct objective value
                 if rescale != 1:

--- a/tiatoolbox/dataloader/wsireader.py
+++ b/tiatoolbox/dataloader/wsireader.py
@@ -96,7 +96,7 @@ class WSIReader:
             M=end_h-start_h, N=end_w-start_w
 
         """
-        pass
+        raise NotImplementedError
 
     def slide_thumbnail(self):
         """Read whole slide image thumbnail at 1.25x
@@ -108,7 +108,7 @@ class WSIReader:
             ndarray : image array
 
         """
-        pass
+        raise NotImplementedError
 
     def save_tiles(self, tile_format=".jpg"):
         """Generate image tiles from whole slide images.
@@ -270,9 +270,6 @@ class OpenSlideWSIReader(WSIReader):
         tile_read_size_w=5000,
         tile_read_size_h=5000,
     ):
-        """
-        file_path (string): path to single whole-slide image
-        """
         super().__init__(
             input_dir=input_dir,
             file_name=file_name,
@@ -340,7 +337,7 @@ class OpenSlideWSIReader(WSIReader):
         objective_power = np.int(
             self.openslide_obj.properties[openslide.PROPERTY_NAME_OBJECTIVE_POWER]
         )
-        objective_power = objective_power
+
         slide_dimension = self.openslide_obj.level_dimensions[0]
         tile_objective_value = self.tile_objective_value
         rescale = np.int(objective_power / tile_objective_value)

--- a/tiatoolbox/utils/exceptions.py
+++ b/tiatoolbox/utils/exceptions.py
@@ -1,0 +1,8 @@
+"""Custom Errors and Exceptions for TIAToolbox"""
+
+
+class FileNotSupported(Exception):
+    """Raises No supported file found Error"""
+    def __init__(self, message="No supported file found."):
+        self.message = message
+        super().__init__(self.message)

--- a/tiatoolbox/utils/exceptions.py
+++ b/tiatoolbox/utils/exceptions.py
@@ -3,6 +3,6 @@
 
 class FileNotSupported(Exception):
     """Raises No supported file found Error"""
-    def __init__(self, message="No supported file found."):
+    def __init__(self, message="File format is not supported"):
         self.message = message
         super().__init__(self.message)

--- a/tiatoolbox/utils/misc.py
+++ b/tiatoolbox/utils/misc.py
@@ -98,34 +98,3 @@ def imwrite(image_path, img):
     if isinstance(image_path, pathlib.Path):
         image_path = str(image_path)
     cv2.imwrite(image_path, cv2.cvtColor(img, cv2.COLOR_RGB2BGR))
-
-
-def imresize(img, scale_factor, interpolation=cv2.INTER_CUBIC):
-    """Resize input image
-
-    Args:
-        img (ndarray): input image
-        scale_factor (float): scaling factor to resize the input image
-        interpolation (int): interpolation, default=cv2.INTER_CUBIC
-
-    Returns:
-        ndarray: resized image
-
-    Examples:
-            >>> from tiatoolbox.dataloader import wsireader
-            >>> from tiatoolbox.utils import misc
-            >>> wsi_obj = wsireader.WSIReader(input_dir="./",
-            ...     file_name="CMU-1.ndpi")
-            >>> slide_thumbnail = wsi_obj.slide_thumbnail()
-            >>> # Resize the image to half size using scale_factor 0.5
-            >>> misc.imresize(slide_thumbnail, scale_factor=0.5)
-
-    """
-    # Estimate new dimension
-    width = int(img.shape[1] * scale_factor)
-    height = int(img.shape[0] * scale_factor)
-    dim = (width, height)
-    # Resize image
-    resized_img = cv2.resize(img, dim, interpolation=interpolation)
-
-    return resized_img

--- a/tiatoolbox/utils/transforms.py
+++ b/tiatoolbox/utils/transforms.py
@@ -1,6 +1,7 @@
 """Define Image transforms"""
 import numpy as np
 from PIL import Image
+import cv2
 
 
 def background_composite(image, fill=255):
@@ -36,3 +37,34 @@ def background_composite(image, fill=255):
     composite.alpha_composite(image)
     composite = np.asarray(composite.convert("RGB"))
     return composite
+
+
+def imresize(img, scale_factor, interpolation=cv2.INTER_CUBIC):
+    """Resize input image
+
+    Args:
+        img (ndarray): input image
+        scale_factor (float): scaling factor to resize the input image
+        interpolation (int): interpolation, default=cv2.INTER_CUBIC
+
+    Returns:
+        ndarray: resized image
+
+    Examples:
+            >>> from tiatoolbox.dataloader import wsireader
+            >>> from tiatoolbox.utils import transforms
+            >>> wsi_obj = wsireader.WSIReader(input_dir="./",
+            ...     file_name="CMU-1.ndpi")
+            >>> slide_thumbnail = wsi_obj.slide_thumbnail()
+            >>> # Resize the image to half size using scale_factor 0.5
+            >>> transforms.imresize(slide_thumbnail, scale_factor=0.5)
+
+    """
+    # Estimate new dimension
+    width = int(img.shape[1] * scale_factor)
+    height = int(img.shape[0] * scale_factor)
+    dim = (width, height)
+    # Resize image
+    resized_img = cv2.resize(img, dim, interpolation=interpolation)
+
+    return resized_img

--- a/tiatoolbox/utils/transforms.py
+++ b/tiatoolbox/utils/transforms.py
@@ -30,8 +30,9 @@ def background_composite(image, fill=255):
 
     image = image.convert("RGBA")
 
-    composite = Image.fromarray(np.full(list(image.size[::-1]) + [4], fill,
-                                        dtype=np.uint8))
+    composite = Image.fromarray(
+        np.full(list(image.size[::-1]) + [4], fill, dtype=np.uint8)
+    )
     composite.alpha_composite(image)
     composite = np.asarray(composite.convert("RGB"))
     return composite


### PR DESCRIPTION
- Restructure WSIReader as parent class to allow support to read whole slide images in other formats.
- Add OpenSlideWSIReader
- Add tests for OpenSlideWSIReader
- Add docs for OpenSlideWSIReader
