### PR TITLE
BUG: Fix Reading Thumbnail In WSIReader

### DIFF
--- a/tests/test_tiatoolbox.py
+++ b/tests/test_tiatoolbox.py
@@ -734,13 +734,17 @@ def test_read_bounds_jp2_objective_power(_response_jp2):
         assert im_region.shape[2] == 3
 
 
-def test_wsireader_get_thumbnail(_response_svs):
+def test_wsireader_get_thumbnail_openslide(_response_svs):
     """Test for get_thumbnail as a python function."""
-    file_types = ("*.svs",)
-    files_all = utils.misc.grab_files_from_dir(
-        input_path=str(pathlib.Path(_response_svs).parent), file_types=file_types,
-    )
-    wsi = wsireader.OpenSlideWSIReader(files_all[0])
+    wsi = wsireader.OpenSlideWSIReader(_response_svs)
+    slide_thumbnail = wsi.get_thumbnail()
+    assert isinstance(slide_thumbnail, np.ndarray)
+    assert slide_thumbnail.dtype == "uint8"
+
+
+def test_wsireader_get_thumbnail_jp2(_response_jp2):
+    """Test for get_thumbnail as a python function."""
+    wsi = wsireader.OmnyxJP2WSIReader(_response_jp2)
     slide_thumbnail = wsi.get_thumbnail()
     assert isinstance(slide_thumbnail, np.ndarray)
     assert slide_thumbnail.dtype == "uint8"

--- a/tiatoolbox/dataloader/wsireader.py
+++ b/tiatoolbox/dataloader/wsireader.py
@@ -580,20 +580,9 @@ class WSIReader:
             ...     file_name="CMU-1.ndpi")
             >>> slide_thumbnail = wsi.slide_thumbnail()
         """
-        level, post_read_scale = self._find_optimal_level_and_downsample(
-            resolution, units
-        )
-        level_dimensions = self.info.level_dimensions[level]
-        bounds = (0, 0, *level_dimensions)
-        thumb = self.read_bounds(bounds, 1.25, "power")
-
-        if np.any(post_read_scale != 1.0):
-            new_size = np.round(np.array(level_dimensions) * post_read_scale)
-            new_size = tuple(new_size.astype(int))
-            thumb = cv2.resize(thumb, new_size, interpolation=cv2.INTER_AREA)
-
-        thumb = np.array(thumb)
-
+        slide_dimensions = self.info.slide_dimensions
+        bounds = (0, 0, *slide_dimensions)
+        thumb = self.read_bounds(bounds, resolution=resolution, units=units)
         return thumb
 
     def save_tiles(self, tile_format=".jpg", verbose=True):


### PR DESCRIPTION
Fixes the `get_thumbnail` function in `WSIReader`. It now uses `read_bounds` with the origin and the slide dimensions as the bounds.