### PR TITLE
NEW: Fallback To Calculate MPP From Standard TIFF Tags

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,9 @@
 from tiatoolbox import utils
 
+import pytest
 import numpy as np
+
+import tiatoolbox
 
 
 def test_imresize():
@@ -20,3 +23,60 @@ def test_background_composite():
 
     im = utils.transforms.background_composite(new_im, alpha=True)
     assert np.all(im[:, :, 3] == 255)
+
+
+def test_mpp2objective_power(_sample_svs):
+    """Test approximation of objective power from mpp."""
+    mapping = [
+        (0.05, 100),
+        (0.07, 100),
+        (0.10, 60),
+        (0.12, 60),
+        (0.15, 40),
+        (0.29, 40),
+        (0.30, 20),
+        (0.49, 20),
+        (0.60, 10),
+        (1.00, 10),
+        (1.20, 5),
+        (2.00, 5),
+        (2.40, 2.5),
+        (3.00, 2.5),
+        (4.80, 1.25),
+        (9.00, 1.25),
+    ]
+    for mpp, result in mapping:
+        assert utils.misc.mpp2objective_power(mpp) == result
+        assert utils.misc.mpp2objective_power([mpp] * 2) == result
+
+    with pytest.raises(ValueError):
+        utils.misc.mpp2objective_power(mpp=10)
+
+    wsi = tiatoolbox.dataloader.wsireader.OpenSlideWSIReader(_sample_svs)
+    openslide_obj = wsi.openslide_wsi
+    dictionary = dict(wsi.openslide_wsi.properties)
+
+    class DummyOpenSlideObject(object):
+        def __getattr__(self, name: str):
+            if name != "properties":
+                return getattr(openslide_obj, name)
+
+        @property
+        def properties(self):
+            return dictionary
+
+    wsi.openslide_wsi = DummyOpenSlideObject()
+
+    del dictionary["openslide.objective-power"]
+    with pytest.warns(UserWarning, match=r"Objective power inferred"):
+        wsi.info
+
+    dictionary["openslide.mpp-x"] = 10
+    dictionary["openslide.mpp-y"] = 10
+    with pytest.warns(UserWarning, match=r"MPP outside of sensible range"):
+        wsi.info
+
+    del dictionary["openslide.mpp-x"]
+    del dictionary["openslide.mpp-y"]
+    with pytest.warns(UserWarning, match=r"Unable to determine objective power"):
+        wsi.info

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,8 +3,6 @@ from tiatoolbox import utils
 import pytest
 import numpy as np
 
-import tiatoolbox
-
 
 def test_imresize():
     """Test for imresize."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,7 +26,7 @@ def test_background_composite():
 
 
 def test_mpp2objective_power(_sample_svs):
-    """Test approximation of objective power from mpp."""
+    """Test approximate conversion of from mpp to objective power."""
     mapping = [
         (0.05, 100),
         (0.07, 100),
@@ -51,32 +51,3 @@ def test_mpp2objective_power(_sample_svs):
 
     with pytest.raises(ValueError):
         utils.misc.mpp2objective_power(mpp=10)
-
-    wsi = tiatoolbox.dataloader.wsireader.OpenSlideWSIReader(_sample_svs)
-    openslide_obj = wsi.openslide_wsi
-    dictionary = dict(wsi.openslide_wsi.properties)
-
-    class DummyOpenSlideObject(object):
-        def __getattr__(self, name: str):
-            if name != "properties":
-                return getattr(openslide_obj, name)
-
-        @property
-        def properties(self):
-            return dictionary
-
-    wsi.openslide_wsi = DummyOpenSlideObject()
-
-    del dictionary["openslide.objective-power"]
-    with pytest.warns(UserWarning, match=r"Objective power inferred"):
-        wsi.info
-
-    dictionary["openslide.mpp-x"] = 10
-    dictionary["openslide.mpp-y"] = 10
-    with pytest.warns(UserWarning, match=r"MPP outside of sensible range"):
-        wsi.info
-
-    del dictionary["openslide.mpp-x"]
-    del dictionary["openslide.mpp-y"]
-    with pytest.warns(UserWarning, match=r"Unable to determine objective power"):
-        wsi.info

--- a/tiatoolbox/dataloader/wsireader.py
+++ b/tiatoolbox/dataloader/wsireader.py
@@ -837,13 +837,16 @@ class OpenSlideWSIReader(WSIReader):
 
         """
         props = self.openslide_wsi.properties
-        objective_power = int(props[openslide.PROPERTY_NAME_OBJECTIVE_POWER])
+        if openslide.PROPERTY_NAME_OBJECTIVE_POWER in props:
+            objective_power = int(props[openslide.PROPERTY_NAME_OBJECTIVE_POWER])
+        else:
+            objective_power = None
 
         slide_dimensions = self.openslide_wsi.level_dimensions[0]
         level_count = self.openslide_wsi.level_count
         level_dimensions = self.openslide_wsi.level_dimensions
         level_downsamples = self.openslide_wsi.level_downsamples
-        vendor = props[openslide.PROPERTY_NAME_VENDOR]
+        vendor = props.get(openslide.PROPERTY_NAME_VENDOR)
 
         # Find microns per pixel (mpp)
         # Initialise to None (value if cannot be determined)

--- a/tiatoolbox/dataloader/wsireader.py
+++ b/tiatoolbox/dataloader/wsireader.py
@@ -837,7 +837,7 @@ class OpenSlideWSIReader(WSIReader):
 
         """
         props = self.openslide_wsi.properties
-        objective_power = np.int(props[openslide.PROPERTY_NAME_OBJECTIVE_POWER])
+        objective_power = int(props[openslide.PROPERTY_NAME_OBJECTIVE_POWER])
 
         slide_dimensions = self.openslide_wsi.level_dimensions[0]
         level_count = self.openslide_wsi.level_count

--- a/tiatoolbox/dataloader/wsireader.py
+++ b/tiatoolbox/dataloader/wsireader.py
@@ -861,14 +861,14 @@ class OpenSlideWSIReader(WSIReader):
             tiff_res_units = props.get("tiff.ResolutionUnit")
             if tiff_res_units is not None:
                 try:
-                    units_per_micron = {
+                    microns_per_unit = {
                         "centimeter": 1e4,  # 10k
                         "inch": 25400,
                     }
                     x_res = float(props["tiff.XResolution"])
                     y_res = float(props["tiff.YResolution"])
-                    mpp_x = 1 / x_res * units_per_micron[tiff_res_units]
-                    mpp_y = 1 / y_res * units_per_micron[tiff_res_units]
+                    mpp_x = 1 / x_res * microns_per_unit[tiff_res_units]
+                    mpp_y = 1 / y_res * microns_per_unit[tiff_res_units]
                     mpp = [mpp_x, mpp_y]
                 except KeyError:
                     warnings.warn("Unable to determine microns-per-pixel")

--- a/tiatoolbox/dataloader/wsireader.py
+++ b/tiatoolbox/dataloader/wsireader.py
@@ -838,7 +838,7 @@ class OpenSlideWSIReader(WSIReader):
         """
         props = self.openslide_wsi.properties
         if openslide.PROPERTY_NAME_OBJECTIVE_POWER in props:
-            objective_power = int(props[openslide.PROPERTY_NAME_OBJECTIVE_POWER])
+            objective_power = float(props[openslide.PROPERTY_NAME_OBJECTIVE_POWER])
         else:
             objective_power = None
 

--- a/tiatoolbox/dataloader/wsireader.py
+++ b/tiatoolbox/dataloader/wsireader.py
@@ -836,17 +836,16 @@ class OpenSlideWSIReader(WSIReader):
             WSIMeta: containing meta information.
 
         """
-        objective_power = np.int(
-            self.openslide_wsi.properties[openslide.PROPERTY_NAME_OBJECTIVE_POWER]
-        )
+        props = self.openslide_wsi.properties
+        objective_power = np.int(props[openslide.PROPERTY_NAME_OBJECTIVE_POWER])
 
         slide_dimensions = self.openslide_wsi.level_dimensions[0]
         level_count = self.openslide_wsi.level_count
         level_dimensions = self.openslide_wsi.level_dimensions
         level_downsamples = self.openslide_wsi.level_downsamples
-        vendor = self.openslide_wsi.properties[openslide.PROPERTY_NAME_VENDOR]
-        mpp_x = self.openslide_wsi.properties[openslide.PROPERTY_NAME_MPP_X]
-        mpp_y = self.openslide_wsi.properties[openslide.PROPERTY_NAME_MPP_Y]
+        vendor = props[openslide.PROPERTY_NAME_VENDOR]
+        mpp_x = props[openslide.PROPERTY_NAME_MPP_X]
+        mpp_y = props[openslide.PROPERTY_NAME_MPP_Y]
         mpp = [mpp_x, mpp_y]
 
         param = WSIMeta(
@@ -858,7 +857,7 @@ class OpenSlideWSIReader(WSIReader):
             level_downsamples=level_downsamples,
             vendor=vendor,
             mpp=mpp,
-            raw=self.openslide_wsi.properties,
+            raw=props,
         )
 
         return param

--- a/tiatoolbox/dataloader/wsireader.py
+++ b/tiatoolbox/dataloader/wsireader.py
@@ -869,6 +869,7 @@ class OpenSlideWSIReader(WSIReader):
                     y_res = float(props["tiff.YResolution"])
                     mpp_x = 1 / x_res * units_per_micron[tiff_res_units]
                     mpp_y = 1 / y_res * units_per_micron[tiff_res_units]
+                    mpp = [mpp_x, mpp_y]
                 except KeyError:
                     warnings.warn("Unable to determine microns-per-pixel")
 

--- a/tiatoolbox/dataloader/wsireader.py
+++ b/tiatoolbox/dataloader/wsireader.py
@@ -870,9 +870,13 @@ class OpenSlideWSIReader(WSIReader):
                     mpp_x = 1 / x_res * microns_per_unit[tiff_res_units]
                     mpp_y = 1 / y_res * microns_per_unit[tiff_res_units]
                     mpp = [mpp_x, mpp_y]
+                    warnings.warn(
+                        "Metadata: Falling back to TIFF resolution tag"
+                        " for microns-per-pixel (MPP)."
+                    )
                 except KeyError:
                     warnings.warn(
-                        "Metadata: Unable to determine microns-per-pixel."
+                        "Metadata: Unable to determine microns-per-pixel (MPP)."
                     )
 
         # Fallback to calculating objective power from mpp
@@ -882,10 +886,13 @@ class OpenSlideWSIReader(WSIReader):
                     objective_power = misc.mpp2objective_power(mpp)
                 except ValueError:
                     warnings.warn(
-                        "Metadata: Unable to approximate objective power from MPP."
-                        "MPP outside of sensible range."
+                        "Metadata: Unable to approximate objective power"
+                        " from microns-per-pixel (MPP)."
+                        " MPP outside of sensible range."
                     )
-                warnings.warn("Metadata: Objective power inferred from MPP.")
+                warnings.warn(
+                    "Metadata: Objective power inferred from microns-per-pixel (MPP)."
+                )
             else:
                 warnings.warn("Metadata: Unable to determine objective power.")
 

--- a/tiatoolbox/utils/misc.py
+++ b/tiatoolbox/utils/misc.py
@@ -200,3 +200,38 @@ def get_luminosity_tissue_mask(img, threshold):
         raise Exception("Empty tissue mask computed")
 
     return tissue_mask
+
+
+def mpp2objective_power(mpp):
+    """Approximate objective power from mpp.
+
+    Ranges for approximation::
+
+            mpp < 0.10 -> 100x
+    0.10 <= mpp < 0.15 -> 60x
+    0.15 <= mpp < 0.30 -> 40x
+    0.30 <= mpp < 0.60 -> 20x
+    0.60 <= mpp < 1.20 -> 10x
+    1.20 <= mpp < 2.40 -> 5x
+    2.40 <= mpp < 4.80 -> 2.5x
+    4.80 <= mpp < 9.60 -> 1.25x
+    9.60 <= mpp -> ValueError
+
+    Args:
+        mpp (float or tuple of float): Microns per-pixel.
+
+    Returns:
+        float: Objective power approximation.
+
+    Raises:
+        ValueError
+    """
+    mpp = np.mean(mpp)
+    if mpp < 0.10:
+        return 100
+    if mpp < 0.15:
+        return 60
+    if mpp < 9.60:
+        # Double the objective power as mpp halves
+        return 10 * 2 ** (np.ceil(np.log2(0.15 / mpp)) + 2)
+    raise ValueError()


### PR DESCRIPTION
This is a draft PR proposing adding some code to calculate the microns-per-picel (MPP) based off of standard TIFF tags.

This is useful in the case where slides and been modified and converted to standard tiles tiffs and use regular TIFF tags instead of putting metadata in the description field (or when created directly as regular tiled TIFFs). In this case openslide does not find the MPP. Examples of such images can be seen in the [PANDA Kaggle challenge dataset](https://www.kaggle.com/c/prostate-cancer-grade-assessment/data).

As always the MPP is not completely reliable. In the future, it would be good to have some method to sanity check the values e.g. to make sure a sensible range or train a model to predict from the image if missing etc.

Also fixes a couple of bugs where the reader would raise an exception and fail if metadata keys could not be found. Now they are simply set to None if not found.