### PR TITLE
HOTFIX: Fix save_tiles

### DIFF
--- a/tiatoolbox/dataloader/wsireader.py
+++ b/tiatoolbox/dataloader/wsireader.py
@@ -649,8 +649,9 @@ class WSIReader:
                 end_w = min(end_w, slide_w)
 
                 # Read image region
-                bounds = start_w, start_h, end_w, end_h
-                im = self.read_bounds(bounds, level)
+                im = self.read_region(location=(start_w, start_h),
+                                      size=(end_w - start_w, end_h - start_h),
+                                      level=level)
 
                 if verbose:
                     format_str = (

--- a/tiatoolbox/dataloader/wsireader.py
+++ b/tiatoolbox/dataloader/wsireader.py
@@ -648,10 +648,10 @@ class WSIReader:
                 end_h = min(end_h, slide_h)
                 end_w = min(end_w, slide_w)
 
+                # convert to baseline reference frame
+                bounds = (start_w, start_h, end_w, end_h) * (2 ** level)
                 # Read image region
-                im = self.read_region(location=(start_w, start_h),
-                                      size=(end_w - start_w, end_h - start_h),
-                                      level=level)
+                im = self.read_bounds(bounds, level)
 
                 if verbose:
                     format_str = (

--- a/tiatoolbox/dataloader/wsireader.py
+++ b/tiatoolbox/dataloader/wsireader.py
@@ -650,7 +650,7 @@ class WSIReader:
 
                 # convert to baseline reference frame
                 bounds = start_w, start_h, end_w, end_h
-                baseline_bounds = tuple([bound * (2 ** 1) for bound in bounds])
+                baseline_bounds = tuple([bound * (2 ** level) for bound in bounds])
                 # Read image region
                 im = self.read_bounds(baseline_bounds, level)
 

--- a/tiatoolbox/dataloader/wsireader.py
+++ b/tiatoolbox/dataloader/wsireader.py
@@ -649,9 +649,10 @@ class WSIReader:
                 end_w = min(end_w, slide_w)
 
                 # convert to baseline reference frame
-                bounds = (start_w, start_h, end_w, end_h) * (2 ** level)
+                bounds = start_w, start_h, end_w, end_h
+                baseline_bounds = tuple([bound * (2 ** 1) for bound in bounds])
                 # Read image region
-                im = self.read_bounds(bounds, level)
+                im = self.read_bounds(baseline_bounds, level)
 
                 if verbose:
                     format_str = (


### PR DESCRIPTION
- convert `bounds` to baseline reference frame in `WSIReader.save_tiles`