### PR TITLE
BUG : Directory input for stainnorm operation

### DIFF
--- a/tiatoolbox/cli.py
+++ b/tiatoolbox/cli.py
@@ -302,7 +302,7 @@ def save_tiles(
     "--file_types",
     help="file types to capture from directory"
     "default='*.png', '*.jpg', '*.tif', '*.tiff'",
-    default="*.png, '*.jpg', '*.tif', '*.tiff'",
+    default="*.png, *.jpg, *.tif, *.tiff",
 )
 def stainnorm(source_input, target_input, method, stain_matrix, output_dir, file_types):
     """Stain normalise an input image/directory of input images."""


### PR DESCRIPTION
Fix a bug in taking directory input for stainnorm operation. All files should be read from the input text if it is a directory instead of returning an empty list.

Note: It is a critical bug fix as it changed the syntax of default file types, which is a common input for all commands and that's why affects all other operations. 