### PR TITLE
NEW: Improve Metadata Estimation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ import sys
 
 sys.path.insert(0, os.path.abspath(".."))
 
-import tiatoolbox
+import tiatoolbox  # noqa: E402
 
 # -- General configuration ---------------------------------------------
 
@@ -36,6 +36,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.viewcode",
     "sphinx.ext.napoleon",
+    "sphinx.ext.mathjax",
     "recommonmark",
 ]
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -71,7 +71,11 @@ Miscellaneous
 -------------
 
 .. automodule:: tiatoolbox.utils.misc
-    :members: save_yaml, split_path_name_ext, grab_files_from_dir, imwrite, load_stain_matrix, imread, get_luminosity_tissue_mask
+    :members:
+
+    .. autofunction:: mpp2objective_power(mpp)
+    .. autofunction:: objective_power2mpp(objective_power)
+    .. autofunction:: mpp2common_objective_power(mpp, common_powers)
 
 ----------
 Transforms

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -50,7 +50,6 @@ Stain Normalisation
 
 .. automodule:: tiatoolbox.tools.stainnorm
     :members: StainNormaliser, CustomNormaliser, RuifrokNormaliser, MacenkoNormaliser, VahadaneNormaliser, ReinhardNormaliser, get_stain_normaliser
-    :special-members: __init__
     :show-inheritance:
 
 ^^^^^^^^^^^^^^^^^^

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -23,29 +23,30 @@ def test_background_composite():
     assert np.all(im[:, :, 3] == 255)
 
 
-def test_mpp2objective_power(_sample_svs):
-    """Test approximate conversion of from mpp to objective power."""
+def test_mpp2common_objective_power(_sample_svs):
+    """Test approximate conversion of mpp to objective power."""
     mapping = [
         (0.05, 100),
         (0.07, 100),
-        (0.10, 60),
-        (0.12, 60),
-        (0.15, 40),
+        (0.10, 100),
+        (0.12, 90),
+        (0.15, 60),
         (0.29, 40),
-        (0.30, 20),
+        (0.30, 40),
         (0.49, 20),
-        (0.60, 10),
+        (0.60, 20),
         (1.00, 10),
-        (1.20, 5),
+        (1.20, 10),
         (2.00, 5),
-        (2.40, 2.5),
-        (3.00, 2.5),
-        (4.80, 1.25),
-        (9.00, 1.25),
+        (2.40, 4),
+        (3.00, 4),
+        (4.0, 2.5),
+        (4.80, 2),
+        (8.00, 1.25),
+        (9.00, 1),
     ]
     for mpp, result in mapping:
         assert utils.misc.mpp2common_objective_power(mpp) == result
-        assert utils.misc.mpp2common_objective_power([mpp] * 2) == result
-
-    with pytest.raises(ValueError):
-        utils.misc.mpp2common_objective_power(mpp=10)
+        assert np.array_equal(
+            utils.misc.mpp2common_objective_power([mpp] * 2), [result] * 2
+        )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,5 @@
 from tiatoolbox import utils
 
-import pytest
 import numpy as np
 
 
@@ -26,29 +25,30 @@ def test_background_composite():
     assert np.all(im[:, :, 3] == 255)
 
 
-def test_mpp2objective_power(_sample_svs):
-    """Test approximate conversion of from mpp to objective power."""
+def test_mpp2common_objective_power(_sample_svs):
+    """Test approximate conversion of mpp to objective power."""
     mapping = [
         (0.05, 100),
         (0.07, 100),
-        (0.10, 60),
-        (0.12, 60),
-        (0.15, 40),
+        (0.10, 100),
+        (0.12, 90),
+        (0.15, 60),
         (0.29, 40),
-        (0.30, 20),
+        (0.30, 40),
         (0.49, 20),
-        (0.60, 10),
+        (0.60, 20),
         (1.00, 10),
-        (1.20, 5),
+        (1.20, 10),
         (2.00, 5),
-        (2.40, 2.5),
-        (3.00, 2.5),
-        (4.80, 1.25),
-        (9.00, 1.25),
+        (2.40, 4),
+        (3.00, 4),
+        (4.0, 2.5),
+        (4.80, 2),
+        (8.00, 1.25),
+        (9.00, 1),
     ]
     for mpp, result in mapping:
-        assert utils.misc.mpp2objective_power(mpp) == result
-        assert utils.misc.mpp2objective_power([mpp] * 2) == result
-
-    with pytest.raises(ValueError):
-        utils.misc.mpp2objective_power(mpp=10)
+        assert utils.misc.mpp2common_objective_power(mpp) == result
+        assert np.array_equal(
+            utils.misc.mpp2common_objective_power([mpp] * 2), [result] * 2
+        )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -44,8 +44,8 @@ def test_mpp2objective_power(_sample_svs):
         (9.00, 1.25),
     ]
     for mpp, result in mapping:
-        assert utils.misc.mpp2objective_power(mpp) == result
-        assert utils.misc.mpp2objective_power([mpp] * 2) == result
+        assert utils.misc.mpp2common_objective_power(mpp) == result
+        assert utils.misc.mpp2common_objective_power([mpp] * 2) == result
 
     with pytest.raises(ValueError):
-        utils.misc.mpp2objective_power(mpp=10)
+        utils.misc.mpp2common_objective_power(mpp=10)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 from tiatoolbox import utils
 
+import pytest
 import numpy as np
 
 
@@ -25,30 +26,29 @@ def test_background_composite():
     assert np.all(im[:, :, 3] == 255)
 
 
-def test_mpp2common_objective_power(_sample_svs):
-    """Test approximate conversion of mpp to objective power."""
+def test_mpp2objective_power(_sample_svs):
+    """Test approximate conversion of from mpp to objective power."""
     mapping = [
         (0.05, 100),
         (0.07, 100),
-        (0.10, 100),
-        (0.12, 90),
-        (0.15, 60),
+        (0.10, 60),
+        (0.12, 60),
+        (0.15, 40),
         (0.29, 40),
-        (0.30, 40),
+        (0.30, 20),
         (0.49, 20),
-        (0.60, 20),
+        (0.60, 10),
         (1.00, 10),
-        (1.20, 10),
+        (1.20, 5),
         (2.00, 5),
-        (2.40, 4),
-        (3.00, 4),
-        (4.0, 2.5),
-        (4.80, 2),
-        (8.00, 1.25),
-        (9.00, 1),
+        (2.40, 2.5),
+        (3.00, 2.5),
+        (4.80, 1.25),
+        (9.00, 1.25),
     ]
     for mpp, result in mapping:
-        assert utils.misc.mpp2common_objective_power(mpp) == result
-        assert np.array_equal(
-            utils.misc.mpp2common_objective_power([mpp] * 2), [result] * 2
-        )
+        assert utils.misc.mpp2objective_power(mpp) == result
+        assert utils.misc.mpp2objective_power([mpp] * 2) == result
+
+    with pytest.raises(ValueError):
+        utils.misc.mpp2objective_power(mpp=10)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,5 @@
 from tiatoolbox import utils
 
-import pytest
 import numpy as np
 
 

--- a/tests/test_wsireader.py
+++ b/tests/test_wsireader.py
@@ -862,11 +862,6 @@ def test_openslide_objective_power_from_mpp(_sample_svs):
     with pytest.warns(UserWarning, match=r"Objective power inferred"):
         _ = wsi.info
 
-    props["openslide.mpp-x"] = 10
-    props["openslide.mpp-y"] = 10
-    with pytest.warns(UserWarning, match=r"MPP outside of sensible range"):
-        _ = wsi.info
-
     del props["openslide.mpp-x"]
     del props["openslide.mpp-y"]
     with pytest.warns(UserWarning, match=r"Unable to determine objective power"):

--- a/tests/test_wsireader.py
+++ b/tests/test_wsireader.py
@@ -930,11 +930,6 @@ def test_openslide_objective_power_from_mpp(_sample_svs):
     with pytest.warns(UserWarning, match=r"Objective power inferred"):
         _ = wsi._info()
 
-    props["openslide.mpp-x"] = 10
-    props["openslide.mpp-y"] = 10
-    with pytest.warns(UserWarning, match=r"MPP outside of sensible range"):
-        _ = wsi._info()
-
     del props["openslide.mpp-x"]
     del props["openslide.mpp-y"]
     with pytest.warns(UserWarning, match=r"Unable to determine objective power"):

--- a/tests/test_wsireader.py
+++ b/tests/test_wsireader.py
@@ -929,10 +929,12 @@ def test_openslide_objective_power_from_mpp(_sample_svs):
     del props["openslide.objective-power"]
     with pytest.warns(UserWarning, match=r"Objective power inferred"):
         _ = wsi._info()
+
     props["openslide.mpp-x"] = 10
     props["openslide.mpp-y"] = 10
     with pytest.warns(UserWarning, match=r"MPP outside of sensible range"):
         _ = wsi._info()
+
     del props["openslide.mpp-x"]
     del props["openslide.mpp-y"]
     with pytest.warns(UserWarning, match=r"Unable to determine objective power"):

--- a/tiatoolbox/dataloader/slide_info.py
+++ b/tiatoolbox/dataloader/slide_info.py
@@ -54,16 +54,12 @@ def slide_info(input_path, verbose=True):
         print(input_path.name, flush=True)
 
     if input_path.suffix in (".svs", ".ndpi", ".mrxs"):
-        wsi_reader = wsireader.OpenSlideWSIReader(
-            input_img=input_path
-        )
+        wsi_reader = wsireader.OpenSlideWSIReader(input_img=input_path)
         info = wsi_reader.info
         if verbose:
             print(info.as_dict())
     elif input_path.suffix in (".jp2",):
-        wsi_reader = wsireader.OmnyxJP2WSIReader(
-            input_img=input_path
-        )
+        wsi_reader = wsireader.OmnyxJP2WSIReader(input_img=input_path)
         info = wsi_reader.info
         if verbose:
             print(info.as_dict())

--- a/tiatoolbox/dataloader/wsireader.py
+++ b/tiatoolbox/dataloader/wsireader.py
@@ -887,7 +887,7 @@ class OpenSlideWSIReader(WSIReader):
         if objective_power is None:
             if mpp is not None:
                 try:
-                    objective_power = misc.mpp2objective_power(mpp)
+                    objective_power = misc.mpp2common_objective_power(mpp)
                 except ValueError:
                     warnings.warn(
                         "Metadata: Unable to approximate objective power"

--- a/tiatoolbox/dataloader/wsireader.py
+++ b/tiatoolbox/dataloader/wsireader.py
@@ -877,7 +877,14 @@ class OpenSlideWSIReader(WSIReader):
         # Fallback to calculating objective power from mpp
         if objective_power is None:
             if mpp is not None:
-                objective_power = misc.mpp2common_objective_power(np.mean(mpp))
+                try:
+                    objective_power = misc.mpp2objective_power(mpp)
+                except ValueError:
+                    warnings.warn(
+                        "Metadata: Unable to approximate objective power"
+                        " from microns-per-pixel (MPP)."
+                        " MPP outside of sensible range."
+                    )
                 warnings.warn(
                     "Metadata: Objective power inferred from microns-per-pixel (MPP)."
                 )

--- a/tiatoolbox/dataloader/wsireader.py
+++ b/tiatoolbox/dataloader/wsireader.py
@@ -887,7 +887,7 @@ class OpenSlideWSIReader(WSIReader):
         if objective_power is None:
             if mpp is not None:
                 try:
-                    objective_power = misc.mpp2common_objective_power(mpp)
+                    objective_power = misc.mpp2common_objective_power(np.mean(mpp))
                 except ValueError:
                     warnings.warn(
                         "Metadata: Unable to approximate objective power"

--- a/tiatoolbox/dataloader/wsireader.py
+++ b/tiatoolbox/dataloader/wsireader.py
@@ -877,14 +877,7 @@ class OpenSlideWSIReader(WSIReader):
         # Fallback to calculating objective power from mpp
         if objective_power is None:
             if mpp is not None:
-                try:
-                    objective_power = misc.mpp2objective_power(mpp)
-                except ValueError:
-                    warnings.warn(
-                        "Metadata: Unable to approximate objective power"
-                        " from microns-per-pixel (MPP)."
-                        " MPP outside of sensible range."
-                    )
+                objective_power = misc.mpp2common_objective_power(np.mean(mpp))
                 warnings.warn(
                     "Metadata: Objective power inferred from microns-per-pixel (MPP)."
                 )

--- a/tiatoolbox/dataloader/wsireader.py
+++ b/tiatoolbox/dataloader/wsireader.py
@@ -886,14 +886,7 @@ class OpenSlideWSIReader(WSIReader):
         # Fallback to calculating objective power from mpp
         if objective_power is None:
             if mpp is not None:
-                try:
-                    objective_power = misc.mpp2common_objective_power(np.mean(mpp))
-                except ValueError:
-                    warnings.warn(
-                        "Metadata: Unable to approximate objective power"
-                        " from microns-per-pixel (MPP)."
-                        " MPP outside of sensible range."
-                    )
+                objective_power = misc.mpp2common_objective_power(np.mean(mpp))
                 warnings.warn(
                     "Metadata: Objective power inferred from microns-per-pixel (MPP)."
                 )

--- a/tiatoolbox/utils/misc.py
+++ b/tiatoolbox/utils/misc.py
@@ -223,7 +223,6 @@ def mpp2common_objective_power(
     distances = [np.abs(op - power) for power in common_powers]
     closest_match = common_powers[np.argmin(distances)]
     return closest_match
-    # raise ValueError("No sensible common objective power for given mpp")
 
 
 @np.vectorize

--- a/tiatoolbox/utils/misc.py
+++ b/tiatoolbox/utils/misc.py
@@ -208,20 +208,10 @@ def mpp2common_objective_power(
 ):
     """Approximate (commonly used round value) of objective power from mpp.
 
-    Ranges for approximation::
-
-            mpp < 0.10 -> 100x
-    0.10 <= mpp < 0.15 -> 60x
-    0.15 <= mpp < 0.30 -> 40x
-    0.30 <= mpp < 0.60 -> 20x
-    0.60 <= mpp < 1.20 -> 10x
-    1.20 <= mpp < 2.40 -> 5x
-    2.40 <= mpp < 4.80 -> 2.5x
-    4.80 <= mpp < 9.60 -> 1.25x
-    9.60 <= mpp -> ValueError
-
     Args:
         mpp (float or tuple of float): Microns per-pixel.
+        common_powers (list of float): A sequence of objective
+            power values to round to.
 
     Returns:
         float: Objective power approximation.

--- a/tiatoolbox/utils/misc.py
+++ b/tiatoolbox/utils/misc.py
@@ -21,6 +21,7 @@
 """Miscellaneous small functions repeatedly used in tiatoolbox."""
 import cv2
 import pathlib
+from numpy.lib.function_base import vectorize
 import yaml
 import pandas as pd
 import numpy as np
@@ -202,8 +203,11 @@ def get_luminosity_tissue_mask(img, threshold):
     return tissue_mask
 
 
-def mpp2objective_power(mpp):
-    """Approximate objective power from mpp.
+@np.vectorize
+def mpp2common_objective_power(
+    mpp, common_powers=[1, 1.25, 2, 2.5, 4, 5, 10, 20, 40, 60, 90, 100]
+):
+    """Approximate (commonly used round value) of objective power from mpp.
 
     Ranges for approximation::
 
@@ -226,12 +230,44 @@ def mpp2objective_power(mpp):
     Raises:
         ValueError
     """
-    mpp = np.mean(mpp)
-    if mpp < 0.10:
-        return 100
-    if mpp < 0.15:
-        return 60
-    if mpp < 9.60:
-        # Double the objective power as mpp halves
-        return 10 * 2 ** (np.ceil(np.log2(0.15 / mpp)) + 2)
-    raise ValueError()
+    op = mpp2objective_power(mpp)
+    distances = [np.abs(op - power) for power in common_powers]
+    closest_match = common_powers[np.argmin(distances)]
+    return closest_match
+    # raise ValueError("No sensible common objective power for given mpp")
+
+
+@np.vectorize
+def objective_power2mpp(objective_power):
+    """Approximate mpp from objective_power.
+
+
+    Args:
+        objective_power (float or tuple of float): Objective power.
+
+    Returns:
+        float: Microns per-pixel (MPP) approximation.
+
+    Raises:
+        ValueError
+    """
+    return 10 * (np.float(objective_power) ** -1)
+
+
+@np.vectorize
+def mpp2objective_power(mpp):
+    """Approximate objective_power from mpp.
+
+    Alias to func:`objective_power2mpp` as it is a self-inverse function.
+
+
+    Args:
+        objective_power (float or tuple of float): Microns per-pixel.
+
+    Returns:
+        float: Objective power approximation.
+
+    Raises:
+        ValueError
+    """
+    return objective_power2mpp(mpp)

--- a/tiatoolbox/utils/misc.py
+++ b/tiatoolbox/utils/misc.py
@@ -239,7 +239,7 @@ def objective_power2mpp(objective_power):
     Raises:
         ValueError
     """
-    return 10 * (np.float(objective_power) ** -1)
+    return 10 / np.float(objective_power)
 
 
 @np.vectorize

--- a/tiatoolbox/utils/misc.py
+++ b/tiatoolbox/utils/misc.py
@@ -202,23 +202,16 @@ def get_luminosity_tissue_mask(img, threshold):
     return tissue_mask
 
 
-def mpp2objective_power(mpp):
-    """Approximate objective power from mpp.
-
-    Ranges for approximation::
-
-            mpp < 0.10 -> 100x
-    0.10 <= mpp < 0.15 -> 60x
-    0.15 <= mpp < 0.30 -> 40x
-    0.30 <= mpp < 0.60 -> 20x
-    0.60 <= mpp < 1.20 -> 10x
-    1.20 <= mpp < 2.40 -> 5x
-    2.40 <= mpp < 4.80 -> 2.5x
-    4.80 <= mpp < 9.60 -> 1.25x
-    9.60 <= mpp -> ValueError
+@np.vectorize
+def mpp2common_objective_power(
+    mpp, common_powers=(1, 1.25, 2, 2.5, 4, 5, 10, 20, 40, 60, 90, 100)
+):
+    """Approximate (commonly used round value) of objective power from mpp.
 
     Args:
         mpp (float or tuple of float): Microns per-pixel.
+        common_powers (list of float): A sequence of objective
+            power values to round to.
 
     Returns:
         float: Objective power approximation.
@@ -226,12 +219,43 @@ def mpp2objective_power(mpp):
     Raises:
         ValueError
     """
-    mpp = np.mean(mpp)
-    if mpp < 0.10:
-        return 100
-    if mpp < 0.15:
-        return 60
-    if mpp < 9.60:
-        # Double the objective power as mpp halves
-        return 10 * 2 ** (np.ceil(np.log2(0.15 / mpp)) + 2)
-    raise ValueError()
+    op = mpp2objective_power(mpp)
+    distances = [np.abs(op - power) for power in common_powers]
+    closest_match = common_powers[np.argmin(distances)]
+    return closest_match
+
+
+@np.vectorize
+def objective_power2mpp(objective_power):
+    """Approximate mpp from objective_power.
+
+
+    Args:
+        objective_power (float or tuple of float): Objective power.
+
+    Returns:
+        float: Microns per-pixel (MPP) approximation.
+
+    Raises:
+        ValueError
+    """
+    return 10 / np.float(objective_power)
+
+
+@np.vectorize
+def mpp2objective_power(mpp):
+    """Approximate objective_power from mpp.
+
+    Alias to func:`objective_power2mpp` as it is a self-inverse function.
+
+
+    Args:
+        objective_power (float or tuple of float): Microns per-pixel.
+
+    Returns:
+        float: Objective power approximation.
+
+    Raises:
+        ValueError
+    """
+    return objective_power2mpp(mpp)

--- a/tiatoolbox/utils/misc.py
+++ b/tiatoolbox/utils/misc.py
@@ -242,7 +242,7 @@ mpp2common_objective_power = np.vectorize(
 
 @np.vectorize
 def objective_power2mpp(objective_power):
-    """Approximate mpp from objective_power.
+    """Approximate mpp from objective power.
 
     The formula used for estimation is :math:`power = \\frac{10}{mpp}`.
     This is a self-inverse function and therefore
@@ -268,7 +268,7 @@ def objective_power2mpp(objective_power):
 
 @np.vectorize
 def mpp2objective_power(mpp):
-    """Approximate objective_power from mpp.
+    """Approximate objective power from mpp.
 
     Alias to :func:`objective_power2mpp` as it is a self-inverse
     function.

--- a/tiatoolbox/utils/misc.py
+++ b/tiatoolbox/utils/misc.py
@@ -204,7 +204,7 @@ def get_luminosity_tissue_mask(img, threshold):
 
 @np.vectorize
 def mpp2common_objective_power(
-    mpp, common_powers=[1, 1.25, 2, 2.5, 4, 5, 10, 20, 40, 60, 90, 100]
+    mpp, common_powers=(1, 1.25, 2, 2.5, 4, 5, 10, 20, 40, 60, 90, 100)
 ):
     """Approximate (commonly used round value) of objective power from mpp.
 

--- a/tiatoolbox/utils/misc.py
+++ b/tiatoolbox/utils/misc.py
@@ -21,7 +21,6 @@
 """Miscellaneous small functions repeatedly used in tiatoolbox."""
 import cv2
 import pathlib
-from numpy.lib.function_base import vectorize
 import yaml
 import pandas as pd
 import numpy as np

--- a/tiatoolbox/utils/misc.py
+++ b/tiatoolbox/utils/misc.py
@@ -202,22 +202,32 @@ def get_luminosity_tissue_mask(img, threshold):
     return tissue_mask
 
 
-@np.vectorize
 def mpp2common_objective_power(
     mpp, common_powers=(1, 1.25, 2, 2.5, 4, 5, 10, 20, 40, 60, 90, 100)
 ):
-    """Approximate (commonly used round value) of objective power from mpp.
+    """Approximate (commonly used value) of objective power from mpp.
+
+    Uses :func:`mpp2objective_power` to estimate and then rounds to the
+    nearest value in `common_powers`.
 
     Args:
         mpp (float or tuple of float): Microns per-pixel.
         common_powers (list of float): A sequence of objective
-            power values to round to.
+            power values to round to. Defaults to
+            (1, 1.25, 2, 2.5, 4, 5, 10, 20, 40, 60, 90, 100).
 
     Returns:
         float: Objective power approximation.
 
-    Raises:
-        ValueError
+    Examples:
+        >>> mpp2common_objective_power(0.253)
+        array(40)
+
+        >>> mpp2common_objective_power(
+        ...     [0.253, 0.478],
+        ...     common_powers=(10, 20, 40),
+        ... )
+        array([40, 20])
     """
     op = mpp2objective_power(mpp)
     distances = [np.abs(op - power) for power in common_powers]
@@ -225,19 +235,33 @@ def mpp2common_objective_power(
     return closest_match
 
 
+mpp2common_objective_power = np.vectorize(
+    mpp2common_objective_power, excluded={"common_powers"}
+)
+
+
 @np.vectorize
 def objective_power2mpp(objective_power):
     """Approximate mpp from objective_power.
 
+    The formula used for estimation is :math:`power = \\frac{10}{mpp}`.
+    This is a self-inverse function and therefore
+    :func:`mpp2objective_power` is simply an alias to this function.
+
+    Note that this function is wrapped in :class:`numpy.vectorize`.
 
     Args:
         objective_power (float or tuple of float): Objective power.
 
     Returns:
-        float: Microns per-pixel (MPP) approximation.
+        np.ndarray: Microns per-pixel (MPP) approximations.
 
-    Raises:
-        ValueError
+    Examples:
+        >>> objective_power2mpp(40)
+        array(0.25)
+
+        >>> objective_power2mpp([40, 20, 10])
+        array([0.25, 0.5, 1.])
     """
     return 10 / np.float(objective_power)
 
@@ -246,16 +270,24 @@ def objective_power2mpp(objective_power):
 def mpp2objective_power(mpp):
     """Approximate objective_power from mpp.
 
-    Alias to func:`objective_power2mpp` as it is a self-inverse function.
+    Alias to :func:`objective_power2mpp` as it is a self-inverse
+    function.
 
 
     Args:
         objective_power (float or tuple of float): Microns per-pixel.
 
     Returns:
-        float: Objective power approximation.
+        np.ndarray: Objective power approximations.
 
-    Raises:
-        ValueError
+    Examples:
+        >>> objective_power2mpp(0.25)
+        array(40.)
+
+        >>> objective_power2mpp([0.25, 0.5, 1.0])
+        array([40., 20., 10.])
+
+        >>> objective_power2mpp(0.253)
+        array(39.5256917)
     """
     return objective_power2mpp(mpp)

--- a/tiatoolbox/utils/transforms.py
+++ b/tiatoolbox/utils/transforms.py
@@ -64,7 +64,7 @@ def background_composite(image, fill=255, alpha=False):
     return composite
 
 
-def imresize(img, scale_factor=None, output_size=None, interpolation='optimise'):
+def imresize(img, scale_factor=None, output_size=None, interpolation="optimise"):
     """Resize input image.
 
     Args:
@@ -96,7 +96,7 @@ def imresize(img, scale_factor=None, output_size=None, interpolation='optimise')
 
     # Optimise interpolation
     if np.any(scale_factor != 1.0):
-        if interpolation == 'optimise':
+        if interpolation == "optimise":
             if np.any(scale_factor > 1.0):
                 interpolation = cv2.INTER_CUBIC
             else:


### PR DESCRIPTION
- Add a better microns per-pixel (MPP) from objective power estimation function (y = 10 / x) which is continuous and self-inverse i.e. 40 → 0.25, 0.25 → 40, 0.5 → 20, 20 → 0.5, 0.2534 → 39.46, 39.46 → 0.2534 etc.
- Add a method to estimate objective power from MPP but snap to common values e.g. 20x, 40x etc.