### PR TITLE
DEV: Add Pre-Commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,4 +8,4 @@ repos:
     rev: 3.7.9
     hooks:
       - id: flake8
-    additional_dependencies: [flake8-bugbear]
+        additional_dependencies: [flake8-bugbear]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 20.8b1 # Replace by any tag/version: https://github.com/psf/black/tags
+    hooks:
+      - id: black
+        language_version: python3 # Should be a command that runs python3.6+
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.9
+    hooks:
+      - id: flake8
+    additional_dependencies: [flake8-bugbear]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[tool.black]
+line-length = 88
+target-version = ['py36', 'py37', 'py38']
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.eggs
+  | \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | _build
+  | buck-out
+  | build
+  | dist
+  | docs
+  | data
+  | setup.py
+)/
+'''

--- a/requirements.dev.conda.yml
+++ b/requirements.dev.conda.yml
@@ -24,5 +24,8 @@ dependencies:
   - pytest==5.4.2
   - pytest-runner==5.2
   - pre-commit
+  - flake8
+  - flake8-bugbear
+  - black
   - pip:
       - openslide-python==1.1.2

--- a/requirements.dev.conda.yml
+++ b/requirements.dev.conda.yml
@@ -23,5 +23,6 @@ dependencies:
   - scikit-learn==0.23.2
   - pytest==5.4.2
   - pytest-runner==5.2
+  - pre-commit
   - pip:
       - openslide-python==1.1.2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -20,3 +20,5 @@ pyyaml
 pandas
 glymur
 pre-commit
+black
+flake8-bugbear

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -19,3 +19,4 @@ matplotlib
 pyyaml
 pandas
 glymur
+pre-commit

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ universal = 1
 [flake8]
 exclude = docs, *__init__*
 max-line-length = 88
+extend-ignore = E203 # For black compatibility
 
 [aliases]
 test = pytest


### PR DESCRIPTION
- Added [pre-commit](https://pre-commit.com/#install) for easy setup of client-side git [hooks](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) for [black code formatting](https://github.com/psf/black#version-control-integration) and flake8 linting.
- Added [flake8-bugbear](https://github.com/PyCQA/flake8-bugbear) to pre-commit for catching potential deepsource errors.

Alternatively (or additionally) [black could be added as a GitHub action](https://github.com/psf/black#github-actions) to format on push or PR.

Could potentially add [Prettier](https://prettier.io/) for non python files (e.g. yaml etc), as used by black and other projects.

# Setting Up Pre-Commit

To set up pre commit on your clone of the repository simply check that you have pre-commit installed (from dev requirements or via homebrew etc.) then run `pre-commit install` from within the repository. 