### PR TITLE
DEV: Update HTML Coverage Recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,9 +57,7 @@ test-all: ## run tests on every Python version with tox
 	tox
 
 coverage: ## check code coverage quickly with the default Python
-	coverage run --source tiatoolbox -m pytest
-	coverage report -m
-	coverage html
+	pytest  --cov=tiatoolbox --cov-report=term --cov-report=html
 	$(BROWSER) htmlcov/index.html
 
 docs: ## generate Sphinx HTML documentation, including API docs

--- a/requirements.dev.conda.yml
+++ b/requirements.dev.conda.yml
@@ -23,5 +23,6 @@ dependencies:
   - scikit-learn==0.23.2
   - pytest==5.4.2
   - pytest-runner==5.2
+  - pytest-cov
   - pip:
       - openslide-python==1.1.2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -10,6 +10,7 @@ twine==1.14.0
 Click>=7.0
 pytest==5.4.2
 pytest-runner==5.2
+pytest-cov
 opencv-python>=4.0
 openslide-python==1.1.2
 pytest-cov==2.9.0


### PR DESCRIPTION
Change recipe in Makefile for coverage to use pytest-cov instead of coverage. Pytest-cov supports multiprocessing and a few extra bits. Also added pytest-cov to dev requirements so that it will not throw and error when using the recipe. Also for consistency across testing (travis / tox is using pytest-cov and the env is slightly different when using coverage).

To generate test coverage locally run the make recipe:

```bash
$ make coverage
```

This will run the tests and collect coverage before opening the index in a web browser:

![image](https://user-images.githubusercontent.com/4615004/102013978-5ef6b480-3d4b-11eb-8ac8-6db2f340179a.png)

Clicking through to a file will show line-by-line coverage:

![image](https://user-images.githubusercontent.com/4615004/102013988-72a21b00-3d4b-11eb-9efe-d0abfa836702.png)
