### PR TITLE
ENH: Cache Slide Info Property

### DIFF
--- a/tests/test_wsimeta.py
+++ b/tests/test_wsimeta.py
@@ -23,10 +23,16 @@ def test_wsimeta_validate_fail():
     )
     assert meta.validate() is False
 
-    meta = wsimeta.WSIMeta(slide_dimensions=(512, 512), level_downsamples=[1, 2],)
+    meta = wsimeta.WSIMeta(
+        slide_dimensions=(512, 512),
+        level_downsamples=[1, 2],
+    )
     assert meta.validate() is False
 
-    meta = wsimeta.WSIMeta(slide_dimensions=(512, 512), level_downsamples=[1, 2],)
+    meta = wsimeta.WSIMeta(
+        slide_dimensions=(512, 512),
+        level_downsamples=[1, 2],
+    )
     assert meta.validate() is False
 
     meta = wsimeta.WSIMeta(slide_dimensions=(512, 512))

--- a/tests/test_wsimeta.py
+++ b/tests/test_wsimeta.py
@@ -1,6 +1,7 @@
-from tiatoolbox.dataloader import wsimeta, wsireader
-
+import numpy as np
 import pytest
+
+from tiatoolbox.dataloader import wsimeta, wsireader
 
 
 # noinspection PyTypeChecker
@@ -71,3 +72,14 @@ def test_wsimeta_openslidewsireader_svs(_sample_svs, tmp_path):
     wsi_obj = wsireader.OpenSlideWSIReader(_sample_svs)
     meta = wsi_obj.info
     assert meta.validate()
+
+
+def test_wsimeta_setter(_sample_svs):
+    """Test setter for metadata."""
+    wsi = wsireader.OpenSlideWSIReader(_sample_svs)
+    meta = wsi.info
+    assert not np.array_equal(meta.mpp, np.array([1, 1]))
+    meta.mpp = np.array([1, 1])
+    wsi.info = meta
+    assert meta.validate()
+    assert np.array_equal(wsi.info.mpp, np.array([1, 1]))

--- a/tests/test_wsireader.py
+++ b/tests/test_wsireader.py
@@ -895,17 +895,17 @@ def test_openslide_objective_power_from_mpp(_sample_svs):
 
     del props["openslide.objective-power"]
     with pytest.warns(UserWarning, match=r"Objective power inferred"):
-        _ = wsi.info
+        _ = wsi._info()
 
     props["openslide.mpp-x"] = 10
     props["openslide.mpp-y"] = 10
     with pytest.warns(UserWarning, match=r"MPP outside of sensible range"):
-        _ = wsi.info
+        _ = wsi._info()
 
     del props["openslide.mpp-x"]
     del props["openslide.mpp-y"]
     with pytest.warns(UserWarning, match=r"Unable to determine objective power"):
-        _ = wsi.info
+        _ = wsi._info()
 
 
 def test_openslide_mpp_from_tiff_resolution(_sample_svs):

--- a/tests/test_wsireader.py
+++ b/tests/test_wsireader.py
@@ -69,7 +69,8 @@ def test_wsireader_slide_info(_sample_svs, tmp_path):
     """Test for slide_info in WSIReader class as a python function."""
     file_types = ("*.svs",)
     files_all = utils.misc.grab_files_from_dir(
-        input_path=str(pathlib.Path(_sample_svs).parent), file_types=file_types,
+        input_path=str(pathlib.Path(_sample_svs).parent),
+        file_types=file_types,
     )
     wsi = wsireader.OpenSlideWSIReader(files_all[0])
     slide_param = wsi.info
@@ -321,7 +322,10 @@ def test_find_read_rect_params_power(_sample_ndpi):
     # Test a range of objective powers
     for target_scale in [1.25, 2.5, 5, 10, 20]:
         (level, _, read_size, post_read_scale, _) = wsi._find_read_rect_params(
-            location=location, size=size, resolution=target_scale, units="power",
+            location=location,
+            size=size,
+            resolution=target_scale,
+            units="power",
         )
         assert level >= 0
         assert level < wsi.info.level_count
@@ -339,7 +343,10 @@ def test_find_read_rect_params_mpp(_sample_ndpi):
     # Test a range of MPP
     for target_scale in range(1, 10):
         (level, _, read_size, post_read_scale, _) = wsi._find_read_rect_params(
-            location=location, size=size, resolution=target_scale, units="mpp",
+            location=location,
+            size=size,
+            resolution=target_scale,
+            units="mpp",
         )
         assert level >= 0
         assert level < wsi.info.level_count
@@ -601,7 +608,11 @@ def test_read_bounds_openslide_objective_power(_sample_ndpi):
     for objective_power in [20, 10, 5, 2.5, 1.25]:
         downsample = slide_power / objective_power
 
-        im_region = wsi.read_bounds(bounds, resolution=objective_power, units="power",)
+        im_region = wsi.read_bounds(
+            bounds,
+            resolution=objective_power,
+            units="power",
+        )
 
         assert isinstance(im_region, np.ndarray)
         assert im_region.dtype == "uint8"
@@ -619,7 +630,11 @@ def test_read_bounds_interpolated(_sample_svs):
     """
     wsi = wsireader.OpenSlideWSIReader(_sample_svs)
     bounds = (0, 0, 500, 500)
-    im_region = wsi.read_bounds(bounds, resolution=0.1, units="mpp",)
+    im_region = wsi.read_bounds(
+        bounds,
+        resolution=0.1,
+        units="mpp",
+    )
 
     assert 0.1 < wsi.info.mpp[0]
     assert 0.1 < wsi.info.mpp[1]
@@ -640,7 +655,11 @@ def test_read_bounds_jp2_objective_power(_sample_jp2):
     for objective_power in [20, 10, 5, 2.5, 1.25]:
         downsample = slide_power / objective_power
 
-        im_region = wsi.read_bounds(bounds, resolution=objective_power, units="power",)
+        im_region = wsi.read_bounds(
+            bounds,
+            resolution=objective_power,
+            units="power",
+        )
 
         assert isinstance(im_region, np.ndarray)
         assert im_region.dtype == "uint8"
@@ -703,7 +722,8 @@ def test_wsireader_save_tiles(_sample_svs, tmp_path):
     """Test for save_tiles in wsireader as a python function."""
     file_types = ("*.svs",)
     files_all = utils.misc.grab_files_from_dir(
-        input_path=str(pathlib.Path(_sample_svs).parent), file_types=file_types,
+        input_path=str(pathlib.Path(_sample_svs).parent),
+        file_types=file_types,
     )
     wsi = wsireader.OpenSlideWSIReader(files_all[0])
     wsi.save_tiles(
@@ -930,9 +950,9 @@ def test_VFReader():
     file_parent_dir = pathlib.Path(__file__).parent
     wsi = wsireader.VFReader(file_parent_dir.joinpath("data/source_image.png"))
     with pytest.warns(UserWarning, match=r"Unknown scale"):
-        _ = wsi.info
+        _ = wsi._info()
     with pytest.warns(UserWarning, match=r"Raw data is None"):
-        _ = wsi.info
+        _ = wsi._info()
 
     assert wsi.img.shape == (256, 256, 3)
 

--- a/tests/test_wsireader.py
+++ b/tests/test_wsireader.py
@@ -78,6 +78,19 @@ def test_wsireader_slide_info(_sample_svs, tmp_path):
     utils.misc.save_yaml(slide_param.as_dict(), out_path)
 
 
+def test_wsireader_slide_info_cache(_sample_svs, tmp_path):
+    """Test for caching slide_info in WSIReader class as a python function."""
+    file_types = ("*.svs",)
+    files_all = utils.misc.grab_files_from_dir(
+        input_path=str(pathlib.Path(_sample_svs).parent),
+        file_types=file_types,
+    )
+    wsi = wsireader.OpenSlideWSIReader(files_all[0])
+    info = wsi.info
+    cached_info = wsi.info
+    assert info.as_dict() == cached_info.as_dict()
+
+
 def test__relative_level_scales_openslide_baseline(_sample_ndpi):
     """Test openslide relative level scales for pixels per baseline pixel."""
     wsi = wsireader.OpenSlideWSIReader(_sample_ndpi)

--- a/tiatoolbox/dataloader/wsimeta.py
+++ b/tiatoolbox/dataloader/wsimeta.py
@@ -111,9 +111,9 @@ class WSIMeta:
         self.level_count = (
             int(level_count) if level_count is not None else len(self.level_dimensions)
         )
-        self.vendor = vendor
+        self.vendor = str(vendor)
         self.mpp = np.array([float(x) for x in mpp]) if mpp is not None else None
-        self.file_path = file_path
+        self.file_path = Path(file_path) if file_path is not None else None
         self.raw = raw if raw is not None else None
 
         self.validate()

--- a/tiatoolbox/dataloader/wsireader.py
+++ b/tiatoolbox/dataloader/wsireader.py
@@ -24,6 +24,7 @@ from tiatoolbox.dataloader.wsimeta import WSIMeta
 
 import pathlib
 import warnings
+import copy
 import numpy as np
 import openslide
 import glymur
@@ -59,15 +60,33 @@ class WSIReader:
 
     @property
     def info(self):
-        """WSI metadata getter.
+        """WSI metadata property.
 
-
-        Args:
-            self (WSIReader):
+        This property is cached and only generated on the first call.
 
         Returns:
             WSIMetadata: An object containing normalised slide metadata
+        """
+        # In Python>=3.8 this could be replaced with functools.cached_property
+        if hasattr(self, "_m_info"):
+            return copy.deepcopy(self._m_info)
+        self._m_info = self._info()
+        return self._m_info
 
+    @info.setter
+    def info(self, meta):
+        """WSI metadata setter.
+
+        Args:
+            meta (WSIMeta): Metadata object.
+        """
+        self._m_info = meta
+
+    def _info(self):
+        """WSI metadata internal getter used to update info property.
+
+        Returns:
+            WSIMetadata: An object containing normalised slide metadata
         """
         raise NotImplementedError
 
@@ -754,7 +773,7 @@ class OpenSlideWSIReader(WSIReader):
     def __init__(
         self, input_img=".",
     ):
-        super().__init__(input_img=input_img, )
+        super().__init__(input_img=input_img,)
         self.openslide_wsi = openslide.OpenSlide(filename=str(self.input_path))
 
     def read_rect(self, location, size, resolution=0, units="level"):
@@ -770,9 +789,9 @@ class OpenSlideWSIReader(WSIReader):
         im_region = np.array(im_region)
 
         # Resize to correct scale if required
-        im_region = transforms.imresize(img=im_region,
-                                        scale_factor=post_read_scale,
-                                        output_size=size)
+        im_region = transforms.imresize(
+            img=im_region, scale_factor=post_read_scale, output_size=size
+        )
 
         im_region = transforms.background_composite(image=im_region)
         return im_region
@@ -798,9 +817,9 @@ class OpenSlideWSIReader(WSIReader):
         im_region = np.array(im_region)
 
         # Resize to correct scale if required
-        im_region = transforms.imresize(img=im_region,
-                                        scale_factor=post_read_scale,
-                                        output_size=output_size)
+        im_region = transforms.imresize(
+            img=im_region, scale_factor=post_read_scale, output_size=output_size
+        )
 
         im_region = transforms.background_composite(image=im_region)
         return im_region
@@ -900,7 +919,7 @@ class OmnyxJP2WSIReader(WSIReader):
     """
 
     def __init__(self, input_img="."):
-        super().__init__(input_img=input_img, )
+        super().__init__(input_img=input_img,)
         self.glymur_wsi = glymur.Jp2k(filename=str(self.input_path))
 
     def read_rect(self, location, size, resolution=0, units="level"):
@@ -923,9 +942,9 @@ class OmnyxJP2WSIReader(WSIReader):
         glymur_wsi = self.glymur_wsi
         im_region = glymur_wsi.read(rlevel=read_level, area=area)
 
-        im_region = transforms.imresize(img=im_region,
-                                        scale_factor=post_read_scale,
-                                        output_size=size)
+        im_region = transforms.imresize(
+            img=im_region, scale_factor=post_read_scale, output_size=size
+        )
 
         im_region = transforms.background_composite(image=im_region)
         return im_region
@@ -945,9 +964,9 @@ class OmnyxJP2WSIReader(WSIReader):
         # area = (start_y, start_x, end_y, end_x)
         # im_region = glymur_wsi.read(rlevel=read_level, area=area)
 
-        im_region = transforms.imresize(img=im_region,
-                                        scale_factor=post_read_scale,
-                                        output_size=output_size)
+        im_region = transforms.imresize(
+            img=im_region, scale_factor=post_read_scale, output_size=output_size
+        )
 
         im_region = transforms.background_composite(image=im_region)
         return im_region
@@ -1029,7 +1048,7 @@ class VFReader(WSIReader):
     """
 
     def __init__(self, input_img="."):
-        super().__init__(input_img=input_img, )
+        super().__init__(input_img=input_img,)
 
         if isinstance(input_img, np.ndarray):
             self.img = input_img
@@ -1077,14 +1096,14 @@ class VFReader(WSIReader):
         )
 
         im_region = self.img[
-            level_location[1]:level_location[1] + baseline_read_size[1],
-            level_location[0]:level_location[0] + baseline_read_size[0],
+            level_location[1] : level_location[1] + baseline_read_size[1],
+            level_location[0] : level_location[0] + baseline_read_size[0],
             :,
         ]
 
-        im_region = transforms.imresize(img=im_region,
-                                        scale_factor=post_read_scale,
-                                        output_size=size)
+        im_region = transforms.imresize(
+            img=im_region, scale_factor=post_read_scale, output_size=size
+        )
 
         im_region = transforms.background_composite(image=im_region)
         return im_region
@@ -1099,9 +1118,9 @@ class VFReader(WSIReader):
 
         im_region = self.img[start_y:end_y:stride, start_x:end_x:stride]
 
-        im_region = transforms.imresize(img=im_region,
-                                        scale_factor=post_read_scale,
-                                        output_size=output_size)
+        im_region = transforms.imresize(
+            img=im_region, scale_factor=post_read_scale, output_size=output_size
+        )
 
         im_region = transforms.background_composite(image=im_region)
         return im_region

--- a/tiatoolbox/dataloader/wsireader.py
+++ b/tiatoolbox/dataloader/wsireader.py
@@ -824,8 +824,7 @@ class OpenSlideWSIReader(WSIReader):
         im_region = transforms.background_composite(image=im_region)
         return im_region
 
-    @property
-    def info(self):
+    def _info(self):
         """Openslide WSI meta data reader.
 
         Returns:
@@ -971,8 +970,7 @@ class OmnyxJP2WSIReader(WSIReader):
         im_region = transforms.background_composite(image=im_region)
         return im_region
 
-    @property
-    def info(self):
+    def _info(self):
         """JP2 meta data reader.
 
         Returns:
@@ -1056,10 +1054,11 @@ class VFReader(WSIReader):
         else:
             self.img = misc.imread(self.input_path)
 
-    @property
-    def info(self):
-        """Visual Field meta data reader. For missing metadata values such as `mpp` or
-        `objective` the value is set to None.
+    def _info(self):
+        """Visual Field meta data getter.
+        
+        For missing metadata values such as `mpp` or `objective` the value is
+        set to None.
 
         Returns:
             WSIMetadata: containing meta information.

--- a/tiatoolbox/dataloader/wsireader.py
+++ b/tiatoolbox/dataloader/wsireader.py
@@ -900,7 +900,7 @@ class OpenSlideWSIReader(WSIReader):
             level_downsamples=level_downsamples,
             vendor=vendor,
             mpp=mpp,
-            raw=props,
+            raw=dict(**props),
         )
 
         return param

--- a/tiatoolbox/dataloader/wsireader.py
+++ b/tiatoolbox/dataloader/wsireader.py
@@ -1056,7 +1056,7 @@ class VFReader(WSIReader):
 
     def _info(self):
         """Visual Field meta data getter.
-        
+
         For missing metadata values such as `mpp` or `objective` the value is
         set to None.
 


### PR DESCRIPTION
- Add caching to slide info property. This is done by checking if a private `self._m_info` exists and returning it if so, otherwise `self._info` is called to create the info for the first time (or to force regenerating) and the result is assigned to `self._m_info`. This could in future be made much simpler with the `functools.cached_property` decorator in Python 3.8+.
- Add `copy.deepcopy` when retuning info, i.e. return a copy. This prevents accidentally mutating the slide info object.
- Add cast around openslide property (ctype property map) to make it a python dictionary instead. This means that the resulting `WSIMeta` object does not contain any ctypes pointers and is therefore picklable.
- Add a setter for slide info for explicitly updating the info `WSIMeta` object.
- Update tests.