### PR TITLE
REL: Pre-release 0.5.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,61 @@
 History
 =======
 
+0.5.0 (2020-12-30)
+------------------
+### Major and Feature Improvements
+
+- Adds `get_wsireader()` to return appropriate WSIReader.
+- Adds new functions to allow reading of regions using WSIReader at different resolutions given in units of:
+  - microns per-pixel (mpp)
+  - objective lens power (power)
+  - pixels-per baseline (baseline)
+  - resolution level (level)
+- Adds functions for reading regions are `read_bounds` and `read_rect`.
+  - `read_bounds` takes a tuple (left, top, right, bottom) of coordinates in baseline (level 0) reference frame and returns a region bounded by those.
+  - `read_rect` takes one coordinate in baseline reference frame and an output size in pixels.
+- Adds `VirtualWSIReader` as a subclass of WSIReader which can be used to read visual fields (tiles).
+  - `VirtualWSIReader`  accepts ndarray or image path as input.
+- Adds MPP fall back to standard TIFF resolution tags  with warning.
+  - If OpenSlide cannot determine microns per pixel (`mpp`) from the metadata, checks the TIFF resolution units (TIFF tags: `ResolutionUnit`, `XResolution` and  `YResolution`) to calculate MPP. Additionally, add function to estimate missing objective power if MPP is known of derived from TIFF resolution tags.
+- Estimates missing objective power from MPP with warning.
+- Adds example notebooks for stain normalisation and WSI reader.
+- Adds caching to slide info property. This is done by checking if a private `self._m_info` exists and returning it if so, otherwise `self._info` is called to create the info for the first time (or to force regenerating) and the result is assigned to `self._m_info`. This could in future be made much simpler with the `functools.cached_property` decorator in Python 3.8+.
+- Adds pre processing step to stain normalisation where stain matrix encodes colour information from tissue region only.
+
+### Changes to API
+- `read_region` refactored to be backwards compatible with openslide arguments.
+- `slide_info` changed to `info`
+- Updates WSIReader which only takes one input
+- `WSIReader` `input_path` variable changed to `input_img`
+- Adds `tile_read_size`, `tile_objective_value` and `output_dir` to WSIReader.save_tiles()
+- Adds `tile_read_size` as a tuple
+- `transforms.imresize` takes additional arguments `output_size` and interpolation method 'optimise' which selects `cv2.INTER_AREA` for `scale_factor<1` and `cv2.INTER_CUBIC` for `scale_factor>1`
+
+### Bug Fixes and Other Changes
+- Refactors glymur code to use index slicing instead of deprecated read function.
+- Refactors thumbnail code to use `read_bounds` and be a member of the WSIReader base class.
+- Updates `README.md` to clarify installation instructions.
+- Fixes slide_info.py for changes in WSIReader API.
+- Fixes save_tiles.py for changes in WSIReader API.
+- Updates `example_wsiread.ipynb` to reflect the changes in WSIReader.
+- Adds Google Colab and Kaggle links to allow user to run notebooks directly on colab or kaggle.
+- Fixes a bug in taking directory input for stainnorm operation for command line interface.
+- Pins `numpy<=1.19.3` to avoid compatibility issues with opencv.
+- Adds `scikit-image` or `jupyterlab` as a dependency.
+
+### Development related changes
+- Moved `test_wsireader_jp2_save_tiles` to test_wsireader.py.
+- Change recipe in Makefile for coverage to use pytest-cov instead of coverage.
+- Runs travis only on PR.
+- Adds [pre-commit](https://pre-commit.com/#install) for easy setup of client-side git [hooks](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) for [black code formatting](https://github.com/psf/black#version-control-integration) and flake8 linting.
+- Adds [flake8-bugbear](https://github.com/PyCQA/flake8-bugbear) to pre-commit for catching potential deepsource errors.
+- Adds constants for test regions in `test_wsireader.py`.
+- Rearranges `usage.rst` for better readability.
+- Adds `pre-commit`, `flake8`, `flake8-bugbear`, `black`, `pytest-cov` and `recommonmark` as dependency.
+
+
+------------------
 0.4.0 (2020-10-25)
 ------------------
 
@@ -28,6 +83,7 @@ History
 - Removes `pathos` as a dependency
 - Updates `openslide-python` requirement to 1.1.2
 
+------------------
 0.3.0 (2020-07-19)
 ------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.0
+current_version = 0.5.0
 commit = True
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ requirements = [
     "pandas",
     "glymur",
     "scikit-learn==0.23.2",
-    "jupyterlab"
+    "jupyterlab",
 ]
 
 setup_requirements = [
@@ -62,6 +62,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/tialab/tiatoolbox",
-    version="0.4.0",
+    version="0.5.0",
     zip_safe=False,
 )

--- a/tiatoolbox/__init__.py
+++ b/tiatoolbox/__init__.py
@@ -27,7 +27,7 @@ from tiatoolbox import tools
 
 __author__ = """TIA Lab"""
 __email__ = "tialab@dcs.warwick.ac.uk"
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 
 if __name__ == "__main__":
     pass


### PR DESCRIPTION
- Update History for 0.5.0 release
- bump2version 0.5.0

### Major and Feature Improvements

- Adds `get_wsireader()` to return appropriate WSIReader.
- Adds new functions to allow reading of regions using WSIReader at different resolutions given in units of:
  - microns per-pixel (mpp)
  - objective lens power (power)
  - pixels-per baseline (baseline)
  - resolution level (level)
- Adds functions for reading regions are `read_bounds` and `read_rect`.
  - `read_bounds` takes a tuple (left, top, right, bottom) of coordinates in baseline (level 0) reference frame and returns a region bounded by those.
  - `read_rect` takes one coordinate in baseline reference frame and an output size in pixels.
- Adds `VirtualWSIReader` as a subclass of WSIReader which can be used to read visual fields (tiles).
  - `VirtualWSIReader`  accepts ndarray or image path as input.
- Adds MPP fall back to standard TIFF resolution tags  with warning.
  - If OpenSlide cannot determine microns per pixel (`mpp`) from the metadata, checks the TIFF resolution units (TIFF tags: `ResolutionUnit`, `XResolution` and  `YResolution`) to calculate MPP. Additionally, add function to estimate missing objective power if MPP is known of derived from TIFF resolution tags.
- Estimates missing objective power from MPP with warning.
- Adds example notebooks for stain normalisation and WSI reader.
- Adds caching to slide info property. This is done by checking if a private `self._m_info` exists and returning it if so, otherwise `self._info` is called to create the info for the first time (or to force regenerating) and the result is assigned to `self._m_info`. This could in future be made much simpler with the `functools.cached_property` decorator in Python 3.8+.
- Adds pre processing step to stain normalisation where stain matrix encodes colour information from tissue region only.

### Changes to API
- `read_region` refactored to be backwards compatible with openslide arguments.
- `slide_info` changed to `info`
- Updates WSIReader which only takes one input
- `WSIReader` `input_path` variable changed to `input_img`
- Adds `tile_read_size`, `tile_objective_value` and `output_dir` to WSIReader.save_tiles()
- Adds `tile_read_size` as a tuple
- `transforms.imresize` takes additional arguments `output_size` and interpolation method 'optimise' which selects `cv2.INTER_AREA` for `scale_factor<1` and `cv2.INTER_CUBIC` for `scale_factor>1`

### Bug Fixes and Other Changes
- Refactors glymur code to use index slicing instead of deprecated read function.
- Refactors thumbnail code to use `read_bounds` and be a member of the WSIReader base class.
- Updates `README.md` to clarify installation instructions.
- Fixes slide_info.py for changes in WSIReader API.
- Fixes save_tiles.py for changes in WSIReader API.
- Updates `example_wsiread.ipynb` to reflect the changes in WSIReader.
- Adds Google Colab and Kaggle links to allow user to run notebooks directly on colab or kaggle.
- Fixes a bug in taking directory input for stainnorm operation for command line interface.
- Pins `numpy<=1.19.3` to avoid compatibility issues with opencv.
- Adds `scikit-image` or `jupyterlab` as a dependency.

### Development related changes
- Moved `test_wsireader_jp2_save_tiles` to test_wsireader.py.
- Change recipe in Makefile for coverage to use pytest-cov instead of coverage.
- Runs travis only on PR.
- Adds [pre-commit](https://pre-commit.com/#install) for easy setup of client-side git [hooks](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) for [black code formatting](https://github.com/psf/black#version-control-integration) and flake8 linting.
- Adds [flake8-bugbear](https://github.com/PyCQA/flake8-bugbear) to pre-commit for catching potential deepsource errors.
- Adds constants for test regions in `test_wsireader.py`.
- Rearranges `usage.rst` for better readability.
- Adds `pre-commit`, `flake8`, `flake8-bugbear`, `black`, `pytest-cov` and `recommonmark` as dependency.

Co-authored-by: Shan E Ahmed @shaneahmed, John Pocock @John-P, Simon Graham @simongraham, Dang Vu @vqdang, Mostafa Jahanifar @mostafajahanifar  Srijay Deshpande @Srijay-lab, Saad Bashir @rajasaad