### PR TITLE
DOC: Fix Output Path file_path in Example of slide_info

### DIFF
--- a/tiatoolbox/dataloader/slide_info.py
+++ b/tiatoolbox/dataloader/slide_info.py
@@ -44,7 +44,7 @@ def slide_info(input_path, verbose=True):
         >>> for curr_file in files_all:
         ...     slide_param = slide_info(input_path=curr_file)
         ...     utils.misc.save_yaml(slide_param.as_dict(),
-        ...           slide_param.file_name + ".yaml")
+        ...           str(slide_param.file_name) + ".yaml")
         ...     print(slide_param.as_dict())
 
     """


### PR DESCRIPTION
Change the example given for slide_info() so as to make it work on windows. 