### PR TITLE
DOC: Updating wsiread example notebook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ ENV/
 examples/*.py
 # Mac generated
 .DS_Store
+
+# vim/vi generated
+*.swp

--- a/examples/example_wsiread.ipynb
+++ b/examples/example_wsiread.ipynb
@@ -574,6 +574,15 @@
     "plt.axis('off')\n",
     "plt.show()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "![ -d tmp ] && ( echo \"deleting tmp directory\"; rm -rf tmp )"
+   ]
   }
  ],
  "metadata": {

--- a/examples/example_wsiread.ipynb
+++ b/examples/example_wsiread.ipynb
@@ -33,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -41,25 +41,33 @@
     "id": "-WyoecokJLPi",
     "outputId": "5fc1a43d-1368-4ff2-d00b-8521ef18c0ce"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/Users/dbae/current/TiaToolbox/tiatoolbox/examples\n",
+      "deleting tmp directory\n"
+     ]
+    }
+   ],
    "source": [
-    "!apt-get -y install libopenjp2-7-dev libopenjp2-tools openslide-tools"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 1000
-    },
-    "id": "k2FoX6v4JLPi",
-    "outputId": "e7188687-793f-41bf-f110-89e600238080"
-   },
-   "outputs": [],
-   "source": [
-    "!pip install tiatoolbox"
+    "%%bash\n",
+    "[ -d tmp ] && ( echo \"deleting tmp directory\"; rm -rf tmp )\n",
+    "clb=$(env | grep COLAB | wc -c);\n",
+    "if [ $clb -gt 0 ]\n",
+    "then\n",
+    "    echo \"working in colab\"\n",
+    "    pl=$(pip list | grep datascience | wc -c)\n",
+    "    if [ $pl -gt 0 ]\n",
+    "    then\n",
+    "        echo \"uninstalling colab packages with conflicts\"\n",
+    "        pip uninstall -y datascience\n",
+    "        pip uninstall -y albumentations\n",
+    "        apt-get -y install libopenjp2-7-dev libopenjp2-tools openslide-tools\n",
+    "        pip install tiatoolbox\n",
+    "    fi\n",
+    "fi\n"
    ]
   },
   {
@@ -598,7 +606,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.7.8"
   }
  },
  "nbformat": 4,

--- a/examples/example_wsiread.ipynb
+++ b/examples/example_wsiread.ipynb
@@ -33,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -41,16 +41,7 @@
     "id": "-WyoecokJLPi",
     "outputId": "5fc1a43d-1368-4ff2-d00b-8521ef18c0ce"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "/Users/dbae/current/TiaToolbox/tiatoolbox/examples\n",
-      "deleting tmp directory\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%bash\n",
     "[ -d tmp ] && ( echo \"deleting tmp directory\"; rm -rf tmp )\n",

--- a/examples/example_wsiread.ipynb
+++ b/examples/example_wsiread.ipynb
@@ -8,9 +8,9 @@
    "source": [
     "# WSI Reading and Visualisation Example\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/TIA-Lab/tiatoolbox/blob/master/examples/example_wsiread.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "<a href=\"https://colab.research.google.com/github/TIA-Lab/tiatoolbox/blob/example-wsiread/examples/example_wsiread.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
-    "<a href=\"https://kaggle.com/kernels/welcome?src=https://github.com/TIA-Lab/tiatoolbox/blob/master/examples/example_wsiread.ipynb\" target=\"_parent\"><img src=\"https://kaggle.com/static/images/open-in-kaggle.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://kaggle.com/kernels/welcome?src=https://github.com/TIA-Lab/tiatoolbox/blob/example-wsiread/examples/example_wsiread.ipynb\" target=\"_parent\"><img src=\"https://kaggle.com/static/images/open-in-kaggle.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {

--- a/examples/example_wsiread.ipynb
+++ b/examples/example_wsiread.ipynb
@@ -440,11 +440,6 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": []
-  },
-  {
    "cell_type": "markdown",
    "metadata": {
     "id": "YufN4e0qJLPp"

--- a/examples/example_wsiread.ipynb
+++ b/examples/example_wsiread.ipynb
@@ -19,16 +19,18 @@
     "id": "p3l08vukKAWo"
    },
    "source": [
-    "## Prerequisites"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "QkcfpWm_JLPh"
-   },
-   "source": [
-    "*Note*: This notebook assumes that `tiatoolbox` has already been installed. If it isn't, you can install it to your python environment by following guideline from https://github.com/TIA-Lab/tiatoolbox or you can install the stable release by running the cell below."
+    "## About this notebook\n",
+    "This jupyter notebook can be run on any computer with a standard browser and no programming language is required. It can run remotely over the Internet, free of charge, thanks to Google Colaboratory or Kaggle. (The Kaggle version is temporarily unavailable.) To connect with Colab or Kaggle, click on one of the two blue checkboxes above. Check that \"colab\" appears in the browser address bar after you click on \"Open in Colab\". Familiarize yourself with the drop-down menus near the top of the window. You can edit the notebook during the session, for example substituting your own image files for the image files used in this demo. Experiment by changing the parameters of functions. It is not possible for an ordinary user to permanently change this version of the notebook on either Github or colab, so you cannot inadvertently mess it up. Use the notebook's File Menu if you wish to save your own (changed) notebook.\n",
+    "\n",
+    "Before running the notebook outside Colab, set up your Python environment, as explained in the \n",
+    "[README](https://github.com/TIA-Lab/tiatoolbox/blob/develop/README.md#install-python-package) file.\n",
+    "### Welcome to tiatoolbox!\n",
+    "This demo reads a whole slide image (WSI) using tiatoolbox. We load a sample WSI, gather some key information, and then extract some image patches. We demo our modules\n",
+    "`wsireader` [details](https://github.com/TIA-Lab/tiatoolbox/blob/master/tiatoolbox/dataloader/wsireader.py) and\n",
+    "`slide_info` [details](https://github.com/TIA-Lab/tiatoolbox/blob/master/tiatoolbox/dataloader/slide_info.py).\n",
+    "\n",
+    "### First cell in bash\n",
+    "The first line of code ssys that the rest of the cell will be interpreted in bash. The second line removes the directory `tmp` if it exists–a previous run may have created it. The other lines set up a suitable Python environment under Colab. No output is expected if the notebook is either run outside Colab or run under Colab for a second time in the same Colab session. "
    ]
   },
   {
@@ -45,31 +47,23 @@
    "source": [
     "%%bash\n",
     "[ -d tmp ] && ( echo \"deleting tmp directory\"; rm -rf tmp )\n",
-    "clb=$(env | grep COLAB | wc -c);\n",
-    "if [ $clb -gt 0 ]\n",
+    "if [ $(env | grep COLAB | wc -c) -gt 0 ] && [ $( pip list | grep datascience | wc -c) -gt 0 ]\n",
     "then\n",
-    "    echo \"working in colab\"\n",
-    "    pl=$(pip list | grep datascience | wc -c)\n",
-    "    if [ $pl -gt 0 ]\n",
-    "    then\n",
-    "        echo \"uninstalling colab packages with conflicts\"\n",
-    "        pip uninstall -y datascience\n",
-    "        pip uninstall -y albumentations\n",
-    "        apt-get -y install libopenjp2-7-dev libopenjp2-tools openslide-tools\n",
-    "        pip install tiatoolbox\n",
-    "    fi\n",
-    "fi\n"
+    "    echo \"uninstalling colab packages with conflicts\"\n",
+    "    pip uninstall -y datascience\n",
+    "    pip uninstall -y albumentations\n",
+    "    apt-get -y install libopenjp2-7-dev libopenjp2-tools openslide-tools\n",
+    "    pip install tiatoolbox\n",
+    "fi"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
-    "id": "NZbRZb4gJLPj"
+    "id": "hmJxBFzDJLPj"
    },
    "source": [
-    "Welcome to tiatoolbox. This is an example to read a whole slide image (WSI) using tiatoolbox. We will load a sample whole slide image (WSI), check out some key information, then extract some image patches from it. From this, we will examine `wsireader` and `slide_info` modules of the library.\n",
-    "\n",
-    "We will start by importing some libraries required to run this notebook examples."
+    "We import some some standard Python modules, and also the Python module `wsireader` (see [details](https://github.com/TIA-Lab/tiatoolbox/blob/master/tiatoolbox/dataloader/wsireader.py)) written by the Tia Centre team."
    ]
   },
   {
@@ -96,16 +90,9 @@
     "id": "fKterRqUKHnW"
    },
    "source": [
-    "## Reading in a WSI"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "hmJxBFzDJLPj"
-   },
-   "source": [
-    "To start with, we will load a small WSI. This WSI is provided using the path variable  `user_sample_wsi_path`. By default, the value is `None` and the WSI will be downloaded from the web using the provided links instead. When downloading from the web, the WSI will be saved under `data_dir` with the named provided in `sample_file_name`. Additionally, data generated by the notebook will also be stored under `data_dir`. Users should change the `data_dir` to their preferred location."
+    "## Reading in a WSI\n",
+    "\n",
+    "We load a small WSI, specified with the help of the path variable `user_sample_wsi_path`(default value `None`). Unless this None value is changed, the WSI is downloaded from the web, as seen in the code below, and saved with filename given by the variable `sample_file_name` in the directory given by `data_dir`. Data generated by the notebook is stored under data_dir, providing rapid local access."
    ]
   },
   {
@@ -140,7 +127,7 @@
     "id": "vFIP6-aeJLPk"
    },
    "source": [
-    "Now, we will create an `OpenSlideWSIReader` object to load information from the WSI. For this class, the `input_path` is the path pointing to the WSI, while the `output_dir` gives a directory for storing intermediate outputs."
+    "Our code shields the user from the incompatible formats produced by different models of scanners from different vendors. The function `wsireader.get_wsireader` has as input a particular WSI, with a particular image format, and outputs an object `wsi_reader_v1`, whose base class is `WSIreader`, and whose derived class depends on the image format. [See details](https://github.com/TIA-Lab/tiatoolbox/blob/master/tiatoolbox/dataloader/wsireader.py). The reader `wsi_reader_v1` provides important information about the WSI. Member functions obtain pixel- or patch-level information, using format-independent code, as we illustrate below."
    ]
   },
   {
@@ -151,9 +138,9 @@
    },
    "outputs": [],
    "source": [
-    "# create a file handler\n",
-    "wsi_reader = wsireader.get_wsireader(\n",
-    "                input_img=sample_wsi_path)"
+    "wsi_reader_v1 = wsireader.get_wsireader(\n",
+    "                input_img=sample_wsi_path)\n",
+    "print(type(wsi_reader_v1))"
    ]
   },
   {
@@ -162,7 +149,8 @@
     "id": "z5gAhPRIJLPk"
    },
    "source": [
-    "First, let's check the basic WSI information, such as magnification, dimension, etc."
+    "First, let's check the basic WSI information, such as magnification, dimension, etc.\n",
+    "(`mpp`= microns per pixel)."
    ]
   },
   {
@@ -178,8 +166,8 @@
    },
    "outputs": [],
    "source": [
-    "wsi_info = wsi_reader.info.as_dict()\n",
-    "# we will print out each info line by line\n",
+    "wsi_info = wsi_reader_v1.info.as_dict()\n",
+    "# Print one item per line\n",
     "print(*list(wsi_info.items()), sep='\\n')"
    ]
   },
@@ -189,14 +177,9 @@
     "id": "nHIvSsgOJLPl"
    },
    "source": [
-    "We can also load the WSI thumbnail using the `slide_thumbnail` method of the object. The thumbnail can be loaded with different resolution units. For the units, there are:\n",
-    "\n",
-    "- `mpp`: microns per pixel\n",
-    "- `power`: objective power of the scanner\n",
-    "- `level`: the level in within the WSI pyramidal file\n",
-    "- `baseline`: pixels per baseline pixel\n",
-    "\n",
-    "We will load the thumbnail at x1.25 objective power as follows:"
+    "### Thumbnail\n",
+    "To see a thumbnail of the WSI, we use the `slide_thumbnail` method of `wsi_reader_v1`.\n",
+    "We load the thumbnail at x1.25 objective power as follows:"
    ]
   },
   {
@@ -212,7 +195,7 @@
    },
    "outputs": [],
    "source": [
-    "wsi_thumb = wsi_reader.slide_thumbnail(resolution=1.25, units='power')\n",
+    "wsi_thumb = wsi_reader_v1.slide_thumbnail(resolution=1.25, units='power')\n",
     "plt.imshow(wsi_thumb)\n",
     "plt.axis('off')\n",
     "plt.show()\n"
@@ -221,24 +204,15 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "id": "STwiiLT_KS5k"
-   },
-   "source": [
-    "## Masking example"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
     "id": "dgdnGWgpJLPl"
    },
    "source": [
-    "Now, we will see how to use the WSI object by implementing a small task:\n",
+    "## A Mask\n",
     "\n",
-    "*  Get a set of locations from the tissue areas of the WSI thumbnail.\n",
-    "* Visualise patches we got previously then load the patches up for visualization.\n",
+    "Over the next several cells, we will use the WSI object `wsi_thumb`to help \n",
+    "create a collection of patches covering the tissue area, with limited overlapping. We want to be able to visualise these patches at the high resolution of the original WSI, but it is computationally more efficient to work as much as possible with the much smaller low resolution thumbnail.\n",
     "\n",
-    "In order to select only patches within tissue areas, we implement a `simple_get_mask` function to threshold the WSI thumbnail intensity and consequently separate the tissue from the background. Here, we use some extra morphological operations, such as dilation, to refine the output. We often call the area to highlight a specific region in the image a **mask**."
+    "The first task is distinguish between tissue and glass (no tissue) in the image. We compute a ***mask***, by which we mean a binary colouring of the pixels to either black=glass or white=tissue. The white area is deliberately made a little larger than than tissue area, as this will be appropriate for our task. Our function `simple_get_mask`binarises the thumbnail on the basis of pixel intensity, using the Otsu method. Morphological operations improve the result. "
    ]
   },
   {
@@ -260,13 +234,13 @@
     "# an example function using intensity thresholding and morphological operations to obtain tissue regions\n",
     "def simple_get_mask(rgb):\n",
     "    gray = cv2.cvtColor(rgb, cv2.COLOR_RGB2GRAY)\n",
-    "    _, mask = cv2.threshold(gray, 0, 255, cv2.THRESH_OTSU) # threshold using OTSU method\n",
+    "    _, mask = cv2.threshold(gray, 0, 255, cv2.THRESH_OTSU) # threshold using the OTSU method\n",
     "    mask = morphology.remove_small_objects(mask == 0, min_size=100, connectivity=2)\n",
     "    mask = morphology.remove_small_holes(mask, area_threshold=100)\n",
     "    mask = morphology.binary_dilation(mask, morphology.disk(5))\n",
     "    return mask\n",
     "\n",
-    "# plot thumbnail along with its tissue mask\n",
+    "# plot thumbnail (left) with its tissue mask (right)\n",
     "wsi_thumb_mask = simple_get_mask(wsi_thumb)\n",
     "plt.subplot(1,2,1)\n",
     "plt.imshow(wsi_thumb)\n",
@@ -283,7 +257,7 @@
     "id": "ynRtfhgWKcBW"
    },
    "source": [
-    "### Extracting patches"
+    "### Extracting patches 1: Superpixels and `SLIC`"
    ]
   },
   {
@@ -292,7 +266,7 @@
     "id": "xg80eVhgJLPm"
    },
    "source": [
-    "Now, we can write a function to obtain a set of locations from where to extract the patches within the tissue area. The location is defined as the top left coordinates of the source image, along with its corresponding dimensions (height and width). For computational reasons, this operation is done at the thumbnail level (low resolution) and so we will need to map the patch locations and dimensions to the magnification level that we intend to use for patch extraction."
+    "We wish to extract patches from our WSI. We will construct a set of patches covering the tissue region, without too much overlap. This will be achieved using the *SLIC* algorithm, described [here](https://medium.com/@darshita1405/superpixels-and-slic-6b2d8a6e4f08#:~:text=SLIC%20(Simple%20Linear%20Iterative%20Clustering,proximity%20in%20the%20image%20plane.). Our implementation is `slic` from `skimage`. This program segments the tissue region into disjoint ***superpixels***. A superpixel is, by definition, an irregularly shaped, connected union of pixels with common traits. the traits being chosen according to the problem. In `SLIC`, each superpixel consists of pixels that are near each other in the 2d plane of the image, and are also near (or as near as possible, given the various constraints) to each other in 3d colour space. Pixels cluster according to these traits, while, simultaneously, the program aims for a certain number of superpixels (specified by `nr_expected_superpixels`, one of the arguments to `slic`). The result is a collection of superpixels, each superpixel having approximately the same area. The `numpy` array `wsi_superpixels_mask`, output by `slic`, has the same shape as `wsi_thumb_mask`. The $N$ superpixels are numbered $1,2...N-1,N$. Each low resolution pixel in the $i$-th superpixel corresponds to an entry $i$ in the array, and each pixel that is not in any superpixel corresponds to a zero entry."
    ]
   },
   {
@@ -307,13 +281,20 @@
     "from skimage.segmentation import slic\n",
     "from skimage.segmentation import mark_boundaries\n",
     "\n",
-    "# get the super-pixels (a.k.a rois) of the tissue area and extract\n",
-    "# patches centering those super-pixel (a.k.a rois)\n",
-    "lores_mag = 1.25 # the magnification of the thumbnail (lores = low resolution)\n",
-    "hires_mag = 20 # the magnification where the patch would be extracted (hires = high resolution)\n",
-    "hires_patch_size = 128 # expected output patch size at higher resolution\n",
-    "# map the expected patch size at hires to lores\n",
-    "lores_patch_size = int(hires_patch_size / (hires_mag / lores_mag))\n"
+    "lores_mag = 1.25 # thumbnail objective power (lores = low resolution)\n",
+    "hires_mag = 20 # original WSI objective power (hires = high resolution)\n",
+    "hires_patch_size = 128 # 128x128 original WSI pixels\n",
+    "# map patch size at hires to lores\n",
+    "lores_patch_size = int(hires_patch_size / (hires_mag / lores_mag))\n",
+    "nr_expected_superpixels = math.ceil(np.sum(wsi_thumb_mask) / (lores_patch_size ** 2))\n",
+    "    \n",
+    "wsi_superpixels_mask = slic(wsi_thumb,\n",
+    "                    mask=wsi_thumb_mask,\n",
+    "                    n_segments=nr_expected_superpixels,\n",
+    "                    compactness=1000,\n",
+    "                    sigma=1)\n",
+    "\n",
+    "print('#Actual Patches / #Expected Patches : %d/%d' % (np.unique(wsi_superpixels_mask).shape[0], nr_expected_superpixels))"
    ]
   },
   {
@@ -322,7 +303,8 @@
     "id": "X4wYTz-OJLPm"
    },
    "source": [
-    "For this example, we would like to create image patches such that they cover the entire WSI. We will use the super-pixel algorithm *SLIC* from `scikit` to do this. It will split the tissue region into regions of similar size at a low resolution. Then we get the patches which are centred at these regions. We also calculate the expected number of patches that can be obtained with the given size. However, note that the actual number of patches may not be the same as the expected number."
+    " \n",
+    "In the image below, the position of each superpixel is made clear by marking the boundary in yellow. Each centre (blue dot in the image below) of mass of each superpixel is used as the centre of a new square patch. The algorithm encourages the centres to arrange themselves, where possible, in the pattern of a square grid, usually tilted. The patches are all of the same size, and they cover the tissue area. They may overlap, but the overlap is limited. To locate these centres, we need a coordinate system. Instead of familiar `(x,y)` coorThe algorithm encourages the centres to arrange themselves roughly in the pattern of a square grid, usually tilted. dinates, we use `(row,column)` coordinates because our data is held in arrays. The origin is at the top-left of the image, and the first coordinate increases as one moves down. Up to this point, we have worked at low resolution for computational efficiency. But examination of each patch in detail requires the use of high resolution data, and we change coordinates accordingly."
    ]
   },
   {
@@ -339,27 +321,19 @@
    },
    "outputs": [],
    "source": [
-    "nr_expected_rois = math.ceil(np.sum(wsi_thumb_mask) / (lores_patch_size ** 2))\n",
-    "wsi_rois_mask = slic(wsi_thumb,\n",
-    "                    mask=wsi_thumb_mask,\n",
-    "                    n_segments=nr_expected_rois,\n",
-    "                    compactness=1000,\n",
-    "                    sigma=1)\n",
-    "print('#Actual Patches / #Expected Patches : %d/%d' % (np.unique(wsi_rois_mask).shape[0], nr_expected_rois))\n",
-    "\n",
-    "lores_rois_center = center_of_mass(wsi_rois_mask,\n",
-    "                labels=wsi_rois_mask,\n",
-    "                index=np.unique(wsi_rois_mask)[1:])\n",
-    "lores_rois_center = np.array(lores_rois_center) # coordinates is Y, X\n",
-    "lores_rois_center = lores_rois_center.astype(np.int32)\n",
-    "selected_indices = wsi_thumb_mask[lores_rois_center[:,0],lores_rois_center[:,1]]\n",
-    "lores_rois_center = lores_rois_center[selected_indices]\n",
+    "lores_superpixels_center = center_of_mass(wsi_superpixels_mask,\n",
+    "                labels=wsi_superpixels_mask,\n",
+    "                index=np.unique(wsi_superpixels_mask)[1:]) # omit zeros–they correspond to pixels not in any superpx\n",
+    "lores_superpixels_center = np.array(lores_superpixels_center) # coordinates Y,X because 2d-array uses row,col\n",
+    "lores_superpixels_center = lores_superpixels_center.astype(np.int32)\n",
+    "selected_indices = wsi_thumb_mask[lores_superpixels_center[:,0],lores_superpixels_center[:,1]]\n",
+    "lores_superpixels_center = lores_superpixels_center[selected_indices]\n",
     "\n",
     "# show the patches region and their centres of mass\n",
-    "plt.imshow(mark_boundaries(wsi_thumb, wsi_rois_mask))\n",
-    "plt.scatter(lores_rois_center[:,1], lores_rois_center[:,0], s=2)\n",
+    "plt.imshow(mark_boundaries(wsi_thumb, wsi_superpixels_mask))\n",
+    "plt.scatter(lores_superpixels_center[:,1], lores_superpixels_center[:,0], s=2)\n",
     "plt.axis('off')\n",
-    "plt.show()\n"
+    "plt.show()"
    ]
   },
   {
@@ -380,9 +354,9 @@
    "outputs": [],
    "source": [
     "# convert to top left idx at hires_mag level\n",
-    "lores_rois_top_left = (lores_rois_center - (lores_patch_size // 2))\n",
-    "hires_rois_top_left = lores_rois_top_left * (hires_mag / lores_mag)\n",
-    "hires_rois_top_left = hires_rois_top_left.astype(np.int32)"
+    "lores_superpixels_top_left = (lores_superpixels_center - (lores_patch_size // 2))\n",
+    "hires_superpixels_top_left = lores_superpixels_top_left * (hires_mag / lores_mag)\n",
+    "hires_superpixels_top_left = hires_superpixels_top_left.astype(np.int32)"
    ]
   },
   {
@@ -410,12 +384,12 @@
     "nr_viz_patches = 16\n",
     "\n",
     "# for illustration purpose, we only visualise a small number of examples\n",
-    "selected_indices = np.random.randint(0, hires_rois_top_left.shape[0], size=(4*nr_viz_patches,))\n",
-    "hires_rois_top_left = hires_rois_top_left[selected_indices]\n",
+    "selected_indices = np.random.randint(0, hires_superpixels_top_left.shape[0], size=(4*nr_viz_patches,))\n",
+    "hires_superpixel_top_left = hires_superpixels_top_left[selected_indices]\n",
     "\n",
     "patch_list = []\n",
-    "for patch_coord in hires_rois_top_left:\n",
-    "    patch = wsi_reader.read_region(\n",
+    "for patch_coord in hires_superpixels_top_left:\n",
+    "    patch = wsi_reader_v1.read_region(\n",
     "                location=patch_coord[::-1],\n",
     "                level=0, size=hires_patch_size)\n",
     "    patch_list.append(patch)\n",
@@ -436,9 +410,9 @@
     "id": "4PTi0FLQJLPo"
    },
    "source": [
-    "Conversely, if you want to extract the entire WSI (including the background), you can use the built-in `save_tiles` functionality of the `WSIReader` object.\n",
+    "If you want to extract the entire WSI (including the background), you can use the built-in `save_tiles` functionality of the `WSIReader` object.\n",
     "\n",
-    "We start by creating another `WSIReader` object and then save tiles using `save_tiles` function with the keywords `tile_objective_value`, `tile_read_size` and `output_dir`. These correspond to the magnification set for reading patches, their expected width & height and the output destination. For clarity, **tile** refers to very large image patches. For this, tiles are read at 20x objective magnification, each of size 1000x1000, and will be saved at the `tmp` folder within the `run_dir`."
+    "We start by creating another `WSIReader` object and then save tiles using the `save_tiles` function with the keywords `tile_objective_value`, `tile_read_size` and `output_dir`. These correspond to the magnification set for reading patches, their expected width & height and the output destination. The word **tile** refers to a very large image patch. Here, tiles are read at 20x objective magnification, each of size 1000x1000, and will be saved in the `data_dir`."
    ]
   },
   {
@@ -466,12 +440,17 @@
    ]
   },
   {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": []
+  },
+  {
    "cell_type": "markdown",
    "metadata": {
     "id": "YufN4e0qJLPp"
    },
    "source": [
-    "Now, we will check the content of the output folder and plot some tiles for visualization. The extracted tiles would be saved under the folder at `{data_dir}/output/{sample_file_name}`. The folder would contain a Output.csv which summarizes the extracted tiles."
+    "We check the content of the output folder and visualize some tiles. The extracted tiles are saved in the directory `{data_dir}/output/{sample_file_name}`. The folder contains `Output.csv` summarizing the extracted tiles."
    ]
   },
   {
@@ -539,7 +518,7 @@
     "id": "pI-G4ecKJLPq"
    },
    "source": [
-    "The library also provides support for reading WSI in `jp2` format via `OmnyxJP2WSIReader` class. This class has the same interface as the class `OpenSlideWSIReader`. We will briefly illustrate this by downloading a `jp2` WSI from the internet and plot its thumbnail."
+    "The base class `WSIReader` also contains a derived class for WSIs in `jp2` format (see above for more details).We will briefly illustrate this by downloading a `jp2` WSI from the internet and visualize its thumbnail."
    ]
   },
   {
@@ -567,25 +546,18 @@
     "    with open(sample_wsi_path, \"wb\") as f:\n",
     "        f.write(r.content)\n",
     "\n",
-    "wsi_reader = wsireader.get_wsireader(\n",
+    "wsi_reader_v3 = wsireader.get_wsireader(\n",
     "                input_img=sample_wsi_path)\n",
-    "wsi_thumb = wsi_reader.slide_thumbnail(resolution=1.25, units='power')\n",
+    "print(type(wsi_reader_v3))\n",
+    "wsi_thumb = wsi_reader_v3.slide_thumbnail(resolution=1.25, units='power')\n",
     "plt.imshow(wsi_thumb)\n",
     "plt.axis('off')\n",
     "plt.show()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "![ -d tmp ] && ( echo \"deleting tmp directory\"; rm -rf tmp )"
-   ]
   }
  ],
  "metadata": {
+  "celltoolbar": "Raw Cell Format",
   "colab": {
    "name": "example_wsiread.ipynb",
    "provenance": [],


### PR DESCRIPTION
DOC: Updating wsiread example notebook

`example_wsiread.ipynb` I made considerable changes to the text cells, for example giving a better idea of the SLIC algorithm. The text cells have been made clearer, with closer connection to the code, and some confusing text removed or rewritten. The only real change in the code has been in the first cell, which is in bash. This removes the directory /tmp that might have been debris from a previous run, and which initially caused the program to fail . One should expect users running this code to want to run it several times, changing some function arguments, so as to get a better understanding of the demo. I have also changed the names of some of the Python objects, in the interests of clarity. In the text cells, I explained the structure of some of the most important objects. I have not attempted to make the notebook run under Kaggle. It runs without error both on a local computer (with the tiatoolbox package installed) and under Colab---this was a bit tricky because of differences between my bash and the bash on Colab. I have removed the text about units for resolution. I would like to write docs on this subject, probably in Latex->pdf, but I'm not sure where to put such a document (perhaps in the docs directory). I have not touched the example notebook on stain normalization. I have not worked on unit tests for the wsiread notebook, since I still have much to learn about this aspect of the work. I do plan to make good this deficiency in a later PR. I hope this PR will be accepted despite the deficiency. At present, each code cell may or may not have associated output, giving a theoretically exponential number of possible acceptable formats, with consequent difficulties for diff commands and general  maintenance---this is an important issue for the unit tests. @John-P  has indicated to me how to deal with this in the unit tests.