### PR TITLE
BUG: fix non-zero level patch reading bug in FixedWindowPatchExtractor

### DIFF
--- a/tiatoolbox/tools/patchextraction.py
+++ b/tiatoolbox/tools/patchextraction.py
@@ -112,14 +112,14 @@ class PatchExtractor(ABC):
             resolution=self.resolution, units=self.units
         )
 
-        slide_dimension = self.wsi.info.level_dimensions[level]
+        slide_dimension = self.wsi.info.level_dimensions[0]
 
         img_w = slide_dimension[0]
         img_h = slide_dimension[1]
-        img_patch_w = self.patch_size[0]
-        img_patch_h = self.patch_size[1]
-        stride_w = self.stride[0]
-        stride_h = self.stride[1]
+        img_patch_w = self.patch_size[0] * (2 ** level)
+        img_patch_h = self.patch_size[1] * (2 ** level)
+        stride_w = self.stride[0] * (2 ** level)
+        stride_h = self.stride[1] * (2 ** level)
 
         data = []
 


### PR DESCRIPTION
If we want to extract patches from an WSI at level 5 (or 1x magnification for example) using `FixedWindowPatchExtractor`. What happens is that `pathcextractor.

_generate_location_df` generates starting points based on the the wsi size at that specific level and the request size and stride (rational and as expected), however, during the patch extraction the class uses read_rect function like below:

```
data = self.wsi.read_rect(
            location=(int(x), int(y)),
            size=self.patch_size,
            resolution=self.resolution,
            units=self.units,
            pad_mode=self.pad_mode,
            pad_constant_values=self.pad_constant_values,
        )
```

and the problem is that location in read_rect is in terms of the baseline image (level 0). This causes extractor to not extract the patches as expected. 

We fix this by multiplying the the calculated location and strides for patch extraction by `2**label`. Of course, this fix only supports the scenario that patch extraction is done by specifying `level`. 