### PR TITLE
ENH: Add functionality to read through mask in `patchextraction`

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -95,9 +95,6 @@ Patch Extraction
 .. autoclass:: SlidingWindowPatchExtractor
     :show-inheritance:
 
-.. autoclass:: VariableWindowPatchExtractor
-    :show-inheritance:
-
 ^^^^^^^^^^^^^^^^^^^^
 Deep Learning Models
 ^^^^^^^^^^^^^^^^^^^^

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -92,7 +92,7 @@ Patch Extraction
 .. autoclass:: PointsPatchExtractor
     :show-inheritance:
 
-.. autoclass:: FixedWindowPatchExtractor
+.. autoclass:: SlidingWindowPatchExtractor
     :show-inheritance:
 
 .. autoclass:: VariableWindowPatchExtractor

--- a/tests/test_patch_extraction.py
+++ b/tests/test_patch_extraction.py
@@ -85,9 +85,6 @@ def test_get_patch_extractor(_source_image, _patch_extr_csv):
 
     assert isinstance(points, patchextraction.PointsPatchExtractor)
 
-    with pytest.raises(MethodNotSupported):
-        points.merge_patches()
-
     sliding_window = patchextraction.get_patch_extractor(
         input_img=input_img,
         method_name="sliding",
@@ -115,9 +112,6 @@ def test_points_patch_extractor_image_format(
     )
 
     assert isinstance(points.wsi, VirtualWSIReader)
-
-    with pytest.raises(MethodNotSupported):
-        points.merge_patches(patches=None)
 
     points = patchextraction.get_patch_extractor(
         input_img=pathlib.Path(_sample_svs),

--- a/tests/test_patch_extraction.py
+++ b/tests/test_patch_extraction.py
@@ -88,13 +88,13 @@ def test_get_patch_extractor(_source_image, _patch_extr_csv):
     with pytest.raises(MethodNotSupported):
         points.merge_patches()
 
-    fixed_window = patchextraction.get_patch_extractor(
+    sliding_window = patchextraction.get_patch_extractor(
         input_img=input_img,
-        method_name="fixedwindow",
+        method_name="sliding",
         patch_size=(200, 200),
     )
 
-    assert isinstance(fixed_window, patchextraction.FixedWindowPatchExtractor)
+    assert isinstance(sliding_window, patchextraction.SlidingWindowPatchExtractor)
 
     variable_window = patchextraction.get_patch_extractor(
         input_img=input_img,
@@ -233,8 +233,8 @@ def test_points_patch_extractor_jp2(
     assert np.all(data == saved_data)
 
 
-def test_fixed_window_patch_extractor(_patch_extr_vf_image):
-    """Test FixedWindowPatchExtractor for VF."""
+def test_sliding_window_patch_extractor(_patch_extr_vf_image):
+    """Test SlidingWindowPatchExtractor for VF."""
     input_img = pathlib.Path(_patch_extr_vf_image)
 
     stride = (20, 20)
@@ -273,7 +273,7 @@ def test_fixed_window_patch_extractor(_patch_extr_vf_image):
 
     patches = patchextraction.get_patch_extractor(
         input_img=input_img,
-        method_name="fixedwindow",
+        method_name="sliding",
         patch_size=patch_size,
         resolution=0,
         units="level",
@@ -293,7 +293,7 @@ def test_fixed_window_patch_extractor(_patch_extr_vf_image):
     # Test for integer (single) patch_size and stride input
     patches = patchextraction.get_patch_extractor(
         input_img=input_img,
-        method_name="fixedwindow",
+        method_name="sliding",
         patch_size=patch_size[0],
         resolution=0,
         units="level",
@@ -311,15 +311,15 @@ def test_fixed_window_patch_extractor(_patch_extr_vf_image):
     assert np.all(img_patches == img_patches_test)
 
 
-def test_fixedwindow_patch_extractor_ndpi(_sample_ndpi):
-    """Test FixedWindowPatchExtractor for ndpi image."""
+def test_sliding_patch_extractor_ndpi(_sample_ndpi):
+    """Test SlidingWindowPatchExtractor for ndpi image."""
     stride = (40, 20)
     patch_size = (400, 200)
     input_img = pathlib.Path(_sample_ndpi)
 
     patches = patchextraction.get_patch_extractor(
         input_img=input_img,
-        method_name="fixedwindow",
+        method_name="sliding",
         patch_size=patch_size,
         resolution=1,
         units="level",

--- a/tests/test_patch_extraction.py
+++ b/tests/test_patch_extraction.py
@@ -377,7 +377,7 @@ def test_get_coordinates():
     with pytest.raises(ValueError, match=r"stride.*> 1.*"):
         PatchExtractor.get_coordinates([9, 6], [4, 4], [0, 0], within_bound=False)
 
-    # test filter_coordinates method
+    # Tests for filter_coordinates method
     bbox_list = np.array(
         [
             [0, 0, 4, 4],

--- a/tests/test_patch_extraction.py
+++ b/tests/test_patch_extraction.py
@@ -408,7 +408,7 @@ def test_mask_based_patch_extractor_ndpi(_sample_ndpi):
         patch_size=patch_size,
         resolution=res,
         units="level",
-        stride=stride,
+        stride=None,
     )
 
     # read the patch from the second row (y) in the first column
@@ -432,15 +432,15 @@ def test_mask_based_patch_extractor_ndpi(_sample_ndpi):
         patch_size=patch_size,
         resolution=res,
         units="level",
-        stride=stride,
+        stride=stride[0],
     )
 
-    # Test `auto` option for mask
+    # Test `otsu` option for mask
     patches = patchextraction.get_patch_extractor(
         input_img=input_img,
-        input_mask="auto",
+        input_mask="otsu",
         method_name="slidingwindow",
-        patch_size=patch_size,
+        patch_size=patch_size[0],
         resolution=res,
         units="level",
         stride=stride,
@@ -448,7 +448,7 @@ def test_mask_based_patch_extractor_ndpi(_sample_ndpi):
 
     patches = patchextraction.get_patch_extractor(
         input_img=wsi_mask,  # a numpy array to build VirtualSlideReader
-        input_mask="auto",
+        input_mask="morphological",
         method_name="slidingwindow",
         patch_size=patch_size,
         resolution=res,

--- a/tests/test_patch_extraction.py
+++ b/tests/test_patch_extraction.py
@@ -96,14 +96,6 @@ def test_get_patch_extractor(_source_image, _patch_extr_csv):
 
     assert isinstance(sliding_window, patchextraction.SlidingWindowPatchExtractor)
 
-    variable_window = patchextraction.get_patch_extractor(
-        input_img=input_img,
-        method_name="variablewindow",
-        patch_size=(200, 200),
-    )
-
-    assert isinstance(variable_window, patchextraction.VariableWindowPatchExtractor)
-
     with pytest.raises(MethodNotSupported):
         patchextraction.get_patch_extractor("unknown")
 

--- a/tiatoolbox/tools/patchextraction.py
+++ b/tiatoolbox/tools/patchextraction.py
@@ -218,48 +218,6 @@ class SlidingWindowPatchExtractor(PatchExtractor):
         raise NotImplementedError
 
 
-class VariableWindowPatchExtractor(PatchExtractor):
-    """Extract and merge patches using variable sized windows for images and labels.
-
-    Args:
-        stride(tuple(int)): stride in (x, y) direction for patch extraction.
-        label_patch_size(tuple(int)): network output label (width, height).
-
-    Attributes:
-        stride(tuple(int)): stride in (x, y) direction for patch extraction.
-        label_patch_size(tuple(int)): network output label (width, height).
-
-    """
-
-    def __init__(
-        self,
-        input_img,
-        patch_size,
-        resolution=0,
-        units="level",
-        stride=(1, 1),
-        pad_mode="constant",
-        pad_constant_values=0,
-        label_patch_size=None,
-    ):
-        super().__init__(
-            input_img=input_img,
-            patch_size=patch_size,
-            resolution=resolution,
-            units=units,
-            pad_mode=pad_mode,
-            pad_constant_values=pad_constant_values,
-        )
-        self.stride = stride
-        self.label_patch_size = label_patch_size
-
-    def __next__(self):
-        raise NotImplementedError
-
-    def merge_patches(self, patches):
-        raise NotImplementedError
-
-
 class PointsPatchExtractor(PatchExtractor):
     """Extracting patches with specified points as a centre.
 
@@ -313,8 +271,8 @@ def get_patch_extractor(method_name, **kwargs):
     """Return a patch extractor object as requested.
 
     Args:
-        method_name (str): name of patch extraction method, must be one of "point",
-          "sliding", "variablewindow".
+        method_name (str): name of patch extraction method, must be one of "point" or
+          "sliding".
         **kwargs: Keyword arguments passed to :obj:`PatchExtractor`.
 
     Returns:
@@ -331,8 +289,6 @@ def get_patch_extractor(method_name, **kwargs):
         patch_extractor = PointsPatchExtractor(**kwargs)
     elif method_name.lower() == "sliding":
         patch_extractor = SlidingWindowPatchExtractor(**kwargs)
-    elif method_name.lower() == "variablewindow":
-        patch_extractor = VariableWindowPatchExtractor(**kwargs)
     else:
         raise MethodNotSupported
 

--- a/tiatoolbox/tools/patchextraction.py
+++ b/tiatoolbox/tools/patchextraction.py
@@ -115,12 +115,12 @@ class PatchExtractor(ABC):
             self.mask = None
         elif input_mask == "auto":
             if isinstance(self.wsi, wsireader.VirtualWSIReader):
-                self.mask = None
+                self.mask = None  # in case the input vase a VF image
             else:
                 self.mask = self.wsi.tissue_mask(resolution=1.25, units="power")
         else:
             self.mask = wsireader.VirtualWSIReader(
-                self.input_mask, info=self.wsi.info, mode="bool"
+                input_mask, info=self.wsi.info, mode="bool"
             )
         self.within_bound = within_bound
 
@@ -195,9 +195,9 @@ class PatchExtractor(ABC):
             )
             self.coord_list = self.coord_list[selected_coord_idxs]
 
-            if len(self.input_list) == 0:
+            if len(self.coord_list) == 0:
                 raise ValueError(
-                    "No candidate coordinates left after"
+                    "No candidate coordinates left after "
                     "filtering by input_mask positions."
                 )
 
@@ -251,7 +251,7 @@ class PatchExtractor(ABC):
             raise ValueError("`coordinates_list` should be ndarray of integer type.")
         if func is None and coordinates_list.shape[-1] != 4:
             raise ValueError(
-                "Default `func` does not support"
+                "Default `func` does not support "
                 "`coordinates_list` of shape {}.".format(coordinates_list.shape)
             )
         func = default_sel_func if func is None else func

--- a/tiatoolbox/tools/patchextraction.py
+++ b/tiatoolbox/tools/patchextraction.py
@@ -21,7 +21,8 @@
 """This file defines patch extraction methods for deep learning models."""
 from abc import ABC
 import numpy as np
-import math
+
+# import math
 
 from tiatoolbox.wsicore import wsireader
 from tiatoolbox.utils.exceptions import MethodNotSupported
@@ -171,13 +172,20 @@ class PatchExtractor(ABC):
         stride_w = self.stride[0] * level_downsample
         stride_h = self.stride[1] * level_downsample
 
-        data = []
+        coord_list = self.get_coordinates(
+            image_shape=(img_w, img_h),
+            patch_shape=(img_patch_w, img_patch_h),
+            stride_shape=(stride_w, stride_h),
+            within_bound=self.within_bound,
+        )
 
-        for h in range(int(math.ceil((img_h - img_patch_h) / stride_h + 1))):
-            for w in range(int(math.ceil((img_w - img_patch_w) / stride_w + 1))):
-                start_h = h * stride_h
-                start_w = w * stride_w
-                data.append([start_w, start_h, None])
+        data = coord_list[:, :2]  # only use the x_start and y_start
+
+        # for h in range(int(math.ceil((img_h - img_patch_h) / stride_h + 1))):
+        #     for w in range(int(math.ceil((img_w - img_patch_w) / stride_w + 1))):
+        #         start_h = h * stride_h
+        #         start_w = w * stride_w
+        #         data.append([start_w, start_h, None])
 
         self.locations_df = misc.read_locations(input_table=np.array(data))
 

--- a/tiatoolbox/tools/patchextraction.py
+++ b/tiatoolbox/tools/patchextraction.py
@@ -114,7 +114,7 @@ class PatchExtractor(ABC):
         self.stride = None
         if input_mask is None:
             self.mask = None
-        elif input_mask in {"otsu", "morphological"}:
+        elif isinstance(input_mask, str) and input_mask in {"otsu", "morphological"}:
             self.mask = self.wsi.tissue_mask(
                 method=input_mask, resolution=1.25, units="power"
             )

--- a/tiatoolbox/tools/patchextraction.py
+++ b/tiatoolbox/tools/patchextraction.py
@@ -163,7 +163,7 @@ class PatchExtractor(ABC):
 
 
 class SlidingWindowPatchExtractor(PatchExtractor):
-    """Extract and merge patches using sliding fixed sized windows for images and labels.
+    """Extract patches using sliding fixed sized window for images and labels.
 
     Args:
         stride(int or tuple(int)): stride in (x, y) direction for patch extraction,
@@ -202,9 +202,6 @@ class SlidingWindowPatchExtractor(PatchExtractor):
 
         self._generate_location_df()
 
-    def merge_patches(self, patches):
-        raise NotImplementedError
-
 
 class PointsPatchExtractor(PatchExtractor):
     """Extracting patches with specified points as a centre.
@@ -242,16 +239,6 @@ class PointsPatchExtractor(PatchExtractor):
         )
         self.locations_df["y"] = self.locations_df["y"] - int(
             (self.patch_size[1] - 1) / 2
-        )
-
-    def merge_patches(self, patches=None):
-        """Merge patch is not supported by :obj:`PointsPatchExtractor`.
-        Calling this function for :obj:`PointsPatchExtractor` will raise an error. This
-        overrides the merge_patches function in the base class :obj:`PatchExtractor`
-
-        """
-        raise MethodNotSupported(
-            message="Merge patches not supported for PointsPatchExtractor"
         )
 
 

--- a/tiatoolbox/tools/patchextraction.py
+++ b/tiatoolbox/tools/patchextraction.py
@@ -169,8 +169,8 @@ class PatchExtractor(ABC):
         img_h = slide_dimension[1]
         img_patch_w = baseline_read_size[0]
         img_patch_h = baseline_read_size[1]
-        stride_w = self.stride[0] * level_downsample
-        stride_h = self.stride[1] * level_downsample
+        stride_w = int(self.stride[0] * level_downsample)
+        stride_h = int(self.stride[1] * level_downsample)
 
         coord_list = self.get_coordinates(
             image_shape=(img_w, img_h),
@@ -229,7 +229,7 @@ class PatchExtractor(ABC):
 
         if not isinstance(mask_reader, wsireader.VirtualWSIReader):
             raise ValueError("`mask_reader` should be wsireader.VirtualWSIReader.")
-        if not isinstance(coordinates_list, np.ndarray) or np.issubdtype(
+        if not isinstance(coordinates_list, np.ndarray) or not np.issubdtype(
             coordinates_list.dtype, np.integer
         ):
             raise ValueError("`coordinates_list` should be ndarray of integer type.")

--- a/tiatoolbox/tools/patchextraction.py
+++ b/tiatoolbox/tools/patchextraction.py
@@ -110,6 +110,7 @@ class PatchExtractor(ABC):
         self.n = 0
         self.wsi = wsireader.get_wsireader(input_img=input_img)
         self.locations_df = None
+        self.coord_list = None
         self.stride = None
         if input_mask is None:
             self.mask = None

--- a/tiatoolbox/tools/patchextraction.py
+++ b/tiatoolbox/tools/patchextraction.py
@@ -300,17 +300,17 @@ class PatchExtractor(ABC):
         def flat_mesh_grid_coord(x, y):
             """Helper function to obtain coordinate grid."""
             x, y = np.meshgrid(x, y)
-            return np.stack([y.flatten(), x.flatten()], axis=-1)
+            return np.stack([x.flatten(), y.flatten()], axis=-1)
 
         patch_shape = np.array(patch_shape)
-        y_list = np.arange(0, image_shape[0], stride_shape[0])
-        x_list = np.arange(0, image_shape[1], stride_shape[1])
+        x_list = np.arange(0, image_shape[0], stride_shape[0])
+        y_list = np.arange(0, image_shape[1], stride_shape[1])
 
         if within_bound:
-            sel = y_list + patch_shape[0] <= image_shape[0]
-            y_list = y_list[sel]
-            sel = x_list + patch_shape[1] <= image_shape[1]
+            sel = x_list + patch_shape[0] <= image_shape[0]
             x_list = x_list[sel]
+            sel = y_list + patch_shape[1] <= image_shape[1]
+            y_list = y_list[sel]
 
         top_left_list = flat_mesh_grid_coord(x_list, y_list)
         bot_right_list = top_left_list + patch_shape[None]

--- a/tiatoolbox/tools/patchextraction.py
+++ b/tiatoolbox/tools/patchextraction.py
@@ -61,6 +61,10 @@ class PatchExtractor(ABC):
         pad_constant_values (int or tuple(int)): Values to use with
           constant padding. Defaults to 0. See :func:`numpy.pad` for
           more.
+        within_bound (bool): whether to extract patches beyond the
+          input_image size limits. If yes, extracted patches at margins
+          will be padded appropriately based on `pad_constant_values` and
+          `pad_mode`. Default is False.
 
     Attributes:
         wsi(WSIReader): input image for patch extraction of type :obj:`WSIReader`.
@@ -88,6 +92,7 @@ class PatchExtractor(ABC):
         units="level",
         pad_mode="constant",
         pad_constant_values=0,
+        within_bound=False,
     ):
         if isinstance(patch_size, (tuple, list)):
             self.patch_size = (int(patch_size[0]), int(patch_size[1]))
@@ -109,6 +114,7 @@ class PatchExtractor(ABC):
             self.mask = wsireader.VirtualWSIReader(
                 self.input_mask, info=self.wsi.info, mode="bool"
             )
+        self.within_bound = within_bound
 
     def __iter__(self):
         self.n = 0

--- a/tiatoolbox/tools/patchextraction.py
+++ b/tiatoolbox/tools/patchextraction.py
@@ -235,8 +235,8 @@ class PatchExtractor(ABC):
             raise ValueError("`coordinates_list` should be ndarray of integer type.")
         if func is None and coordinates_list.shape[-1] != 4:
             raise ValueError(
-                "`func=None` does not support"
-                "`coordinates_list` of shape %s." % coordinates_list.shape
+                "Default `func` does not support"
+                "`coordinates_list` of shape {}.".format(coordinates_list.shape)
             )
         func = default_sel_func if func is None else func
         flag_list = [func(mask_reader, coord) for coord in coordinates_list]

--- a/tiatoolbox/tools/patchextraction.py
+++ b/tiatoolbox/tools/patchextraction.py
@@ -199,10 +199,10 @@ class PatchExtractor(ABC):
 
         if not isinstance(mask_reader, wsireader.VirtualWSIReader):
             raise ValueError("`mask_reader` should be wsireader.VirtualWSIReader.")
-        if not isinstance(coordinates_list, np.ndarray) and np.issubdtype(
+        if not isinstance(coordinates_list, np.ndarray) or np.issubdtype(
             coordinates_list.dtype, np.integer
         ):
-            raise ValueError("`coordinates_list` should be ndarray.")
+            raise ValueError("`coordinates_list` should be ndarray of integer type.")
         if func is None and coordinates_list.shape[-1] != 4:
             raise ValueError(
                 "`func=None` does not support"

--- a/tiatoolbox/tools/patchextraction.py
+++ b/tiatoolbox/tools/patchextraction.py
@@ -161,18 +161,6 @@ class PatchExtractor(ABC):
 
         return self
 
-    def merge_patches(self, patches):
-        """Merge the patch-level results to get the overall image-level prediction.
-
-        Args:
-            patches: patch-level predictions
-
-        Returns:
-            image: merged prediction
-
-        """
-        raise NotImplementedError
-
 
 class SlidingWindowPatchExtractor(PatchExtractor):
     """Extract and merge patches using sliding fixed sized windows for images and labels.

--- a/tiatoolbox/tools/patchextraction.py
+++ b/tiatoolbox/tools/patchextraction.py
@@ -115,9 +115,12 @@ class PatchExtractor(ABC):
         if input_mask is None:
             self.mask = None
         elif isinstance(input_mask, str) and input_mask in {"otsu", "morphological"}:
-            self.mask = self.wsi.tissue_mask(
-                method=input_mask, resolution=1.25, units="power"
-            )
+            if isinstance(self.wsi, wsireader.VirtualWSIReader):
+                self.mask = None
+            else:
+                self.mask = self.wsi.tissue_mask(
+                    method=input_mask, resolution=1.25, units="power"
+                )
         else:
             self.mask = wsireader.VirtualWSIReader(
                 input_mask, info=self.wsi.info, mode="bool"

--- a/tiatoolbox/tools/patchextraction.py
+++ b/tiatoolbox/tools/patchextraction.py
@@ -340,6 +340,7 @@ class SlidingWindowPatchExtractor(PatchExtractor):
         stride=None,
         pad_mode="constant",
         pad_constant_values=0,
+        within_bound=False,
     ):
         super().__init__(
             input_img=input_img,
@@ -349,6 +350,7 @@ class SlidingWindowPatchExtractor(PatchExtractor):
             units=units,
             pad_mode=pad_mode,
             pad_constant_values=pad_constant_values,
+            within_bound=within_bound,
         )
         if stride is None:
             self.stride = self.patch_size
@@ -381,6 +383,7 @@ class PointsPatchExtractor(PatchExtractor):
         units="level",
         pad_mode="constant",
         pad_constant_values=0,
+        within_bound=False,
     ):
         super().__init__(
             input_img=input_img,
@@ -389,6 +392,7 @@ class PointsPatchExtractor(PatchExtractor):
             units=units,
             pad_mode=pad_mode,
             pad_constant_values=pad_constant_values,
+            within_bound=within_bound,
         )
 
         self.locations_df = misc.read_locations(input_table=locations_list)

--- a/tiatoolbox/tools/patchextraction.py
+++ b/tiatoolbox/tools/patchextraction.py
@@ -174,8 +174,8 @@ class PatchExtractor(ABC):
         raise NotImplementedError
 
 
-class FixedWindowPatchExtractor(PatchExtractor):
-    """Extract and merge patches using fixed sized windows for images and labels.
+class SlidingWindowPatchExtractor(PatchExtractor):
+    """Extract and merge patches using sliding fixed sized windows for images and labels.
 
     Args:
         stride(int or tuple(int)): stride in (x, y) direction for patch extraction,
@@ -314,7 +314,7 @@ def get_patch_extractor(method_name, **kwargs):
 
     Args:
         method_name (str): name of patch extraction method, must be one of "point",
-          "fixedwindow", "variablewindow".
+          "sliding", "variablewindow".
         **kwargs: Keyword arguments passed to :obj:`PatchExtractor`.
 
     Returns:
@@ -329,8 +329,8 @@ def get_patch_extractor(method_name, **kwargs):
     """
     if method_name.lower() == "point":
         patch_extractor = PointsPatchExtractor(**kwargs)
-    elif method_name.lower() == "fixedwindow":
-        patch_extractor = FixedWindowPatchExtractor(**kwargs)
+    elif method_name.lower() == "sliding":
+        patch_extractor = SlidingWindowPatchExtractor(**kwargs)
     elif method_name.lower() == "variablewindow":
         patch_extractor = VariableWindowPatchExtractor(**kwargs)
     else:

--- a/tiatoolbox/tools/patchextraction.py
+++ b/tiatoolbox/tools/patchextraction.py
@@ -161,6 +161,114 @@ class PatchExtractor(ABC):
 
         return self
 
+    @staticmethod
+    def filter_coordinates(
+        mask_reader, coordinates_list, func=None, resolution=None, units=None
+    ):
+        """
+        Return list of flags to indicate which coordinate is valid for patch extraction.
+        Locations are being validated by a custom or build-in `func`.
+        Args:
+            mask_reader (:class:`.VirtualReader`): a virtual pyramidal reader.
+            coordinates_list (ndarray and np.int32): Coordinates to be checked
+            via the `func`. They must be in the same resolution as requested
+            `resolution` and `units`. Must be of shape (N,K) with N is the
+            number of coordinate sets while K varies depending on information form.
+            Such as centroid is K=2 while bounding box is K=4. When using with default
+            `func=None`, `K` is expected to be bounding box of form
+            [start_x, start_y, end_x, end_y].
+            func: A function which taking `reader` and `coordinate` as arguments
+                and return True or False to indicate if the coordinate is valid.
+        Returns:
+            ndarray: list of flags to indicate which coordinate is valid.
+        """
+
+        def default_sel_func(reader: wsireader.VirtualWSIReader, coord: np.ndarray):
+            """Accept coord as long as its box contains bits of mask."""
+            roi = reader.read_bounds(
+                coord,
+                resolution=reader.info.mpp if resolution is None else resolution,
+                units="mpp" if units is None else units,
+                interpolation="nearest",
+            )
+            return np.sum(roi > 0) > 0
+
+        if not isinstance(mask_reader, wsireader.VirtualWSIReader):
+            raise ValueError("`mask_reader` should be wsireader.VirtualWSIReader.")
+        if not isinstance(coordinates_list, np.ndarray) and np.issubdtype(
+            coordinates_list.dtype, np.integer
+        ):
+            raise ValueError("`coordinates_list` should be ndarray.")
+        if func is None and coordinates_list.shape[-1] != 4:
+            raise ValueError(
+                "`func=None` does not support"
+                "`coordinates_list` of shape %s." % coordinates_list.shape
+            )
+        func = default_sel_func if func is None else func
+        flag_list = [func(mask_reader, coord) for coord in coordinates_list]
+        return np.array(flag_list)
+
+    @staticmethod
+    def get_coordinates(
+        image_shape=None,
+        patch_shape=None,
+        stride_shape=None,
+        within_bound=True,
+    ):
+        """Calculate patch tiling coordinates.
+        Args:
+            image_shape: a tuple (int, int) or ndarray of shape (2,).
+            Expected image shape at requested `resolution` and `units`.
+            Expected to be (width, height).
+            patch_shape: a tuple (int, int) or ndarray of shape (2,).
+            Expected shape to read from `reader` at requested `resolution` and `units`.
+            Expected to be (width, height).
+            stride_shape: a tuple(int, int) or ndarray of shape (2,).
+            Expected stride shape to read at requested `resolution` and `units`.
+            Expected to be (width, height).
+        """
+        image_shape = np.array(image_shape)
+        patch_shape = np.array(patch_shape)
+        stride_shape = np.array(stride_shape)
+        if (
+            not np.issubdtype(image_shape.dtype, np.integer)
+            or np.size(image_shape) > 2
+            or np.any(image_shape < 0)
+        ):
+            raise ValueError("Invalid `patch_shape` value %s." % patch_shape)
+        if (
+            not np.issubdtype(patch_shape.dtype, np.integer)
+            or np.size(patch_shape) > 2
+            or np.any(patch_shape < 0)
+        ):
+            raise ValueError("Invalid `patch_shape` value %s." % patch_shape)
+        if (
+            not np.issubdtype(stride_shape.dtype, np.integer)
+            or np.size(stride_shape) > 2
+            or np.any(stride_shape < 0)
+        ):
+            raise ValueError("Invalid `stride_shape` value %s." % stride_shape)
+        if np.any(stride_shape < 1):
+            raise ValueError("`stride_shape` value %s must > 1." % stride_shape)
+
+        def flat_mesh_grid_coord(x, y):
+            """Helper function to obtain coordinate grid."""
+            x, y = np.meshgrid(x, y)
+            return np.stack([y.flatten(), x.flatten()], axis=-1)
+
+        patch_shape = np.array(patch_shape)
+        y_list = np.arange(0, image_shape[0], stride_shape[0])
+        x_list = np.arange(0, image_shape[1], stride_shape[1])
+        if within_bound:  # to check compatible with shan portion
+            sel = y_list + patch_shape[0] <= image_shape[0]
+            y_list = y_list[sel]
+            sel = x_list + patch_shape[1] <= image_shape[1]
+            x_list = x_list[sel]
+        top_left_list = flat_mesh_grid_coord(x_list, y_list)
+        bot_right_list = top_left_list + patch_shape[None]
+        coord_list = np.concatenate([top_left_list, bot_right_list], axis=-1)
+        return coord_list
+
 
 class SlidingWindowPatchExtractor(PatchExtractor):
     """Extract patches using sliding fixed sized window for images and labels.

--- a/tiatoolbox/wsicore/wsireader.py
+++ b/tiatoolbox/wsicore/wsireader.py
@@ -1333,17 +1333,18 @@ class VirtualWSIReader(WSIReader):
         param = WSIMeta(
             file_path=self.input_path,
             objective_power=None,
-            slide_dimensions=self.img.shape[:-1],
+            # align to XY to match with OpenSlide
+            slide_dimensions=self.img.shape[:2][::-1],
             level_count=1,
-            level_dimensions=(self.img.shape[:-1],),
+            level_dimensions=(self.img.shape[:2][::-1],),
             level_downsamples=[1.0],
             vendor=None,
             mpp=None,
             raw=None,
         )
-        self._m_info = param
-
-        return param
+        if self._m_info is None:
+            self._m_info = param
+        return self._m_info
 
     def _find_params_from_baseline(self, location, baseline_read_size):
         """Convert read parameters from (virtual) baseline coordinates.


### PR DESCRIPTION
This PR is focused on `patchextraction` functionality to clean up some part, change the API, and adding new features to it.

The `SlidingWindowPatchExtraction` class will accept the `input_mask` argument to extract patches based on the regions that are highlighted in the `input_mask`. The `input_mask` can be a path to the desired mask mask, a numpy array, `VirtualWSIReader`, or `'auto'`. In case of `'auto'`, a tissue mask is automatically generated for the `input_image` using tiatoolbox `TissueMasker` functionality if the `input_image` is a real WSI, otherwise, no mask will be considered for patch extraction.

- [x] Rewrite the `slidingwindow` patch extraction class to use `get_coordinates` static method for patch bounding box generation.
- [x] Add mask-based patch extraction functionality based on the `filter_coordinates` static method.
- [x] Add tests for coverage.