### PR TITLE
API: changing `FixedWindowPatchExtractor` to `SlidingWindowPatchExtractor`

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -95,9 +95,6 @@ Patch Extraction
 .. autoclass:: SlidingWindowPatchExtractor
     :show-inheritance:
 
-.. autoclass:: VariableWindowPatchExtractor
-    :show-inheritance:
-
 ^^^^^^^^^^^^^^^^^^^^
 Deep Learning Models
 ^^^^^^^^^^^^^^^^^^^^

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -92,7 +92,7 @@ Patch Extraction
 .. autoclass:: PointsPatchExtractor
     :show-inheritance:
 
-.. autoclass:: FixedWindowPatchExtractor
+.. autoclass:: SlidingWindowPatchExtractor
     :show-inheritance:
 
 .. autoclass:: VariableWindowPatchExtractor

--- a/tests/test_patch_extraction.py
+++ b/tests/test_patch_extraction.py
@@ -85,9 +85,6 @@ def test_get_patch_extractor(_source_image, _patch_extr_csv):
 
     assert isinstance(points, patchextraction.PointsPatchExtractor)
 
-    with pytest.raises(MethodNotSupported):
-        points.merge_patches()
-
     sliding_window = patchextraction.get_patch_extractor(
         input_img=input_img,
         method_name="sliding",
@@ -115,9 +112,6 @@ def test_points_patch_extractor_image_format(
     )
 
     assert isinstance(points.wsi, VirtualWSIReader)
-
-    with pytest.raises(MethodNotSupported):
-        points.merge_patches(patches=None)
 
     points = patchextraction.get_patch_extractor(
         input_img=pathlib.Path(_sample_svs),

--- a/tests/test_patch_extraction.py
+++ b/tests/test_patch_extraction.py
@@ -88,13 +88,13 @@ def test_get_patch_extractor(_source_image, _patch_extr_csv):
     with pytest.raises(MethodNotSupported):
         points.merge_patches()
 
-    fixed_window = patchextraction.get_patch_extractor(
+    sliding_window = patchextraction.get_patch_extractor(
         input_img=input_img,
-        method_name="fixedwindow",
+        method_name="sliding",
         patch_size=(200, 200),
     )
 
-    assert isinstance(fixed_window, patchextraction.FixedWindowPatchExtractor)
+    assert isinstance(sliding_window, patchextraction.SlidingWindowPatchExtractor)
 
     variable_window = patchextraction.get_patch_extractor(
         input_img=input_img,
@@ -233,8 +233,8 @@ def test_points_patch_extractor_jp2(
     assert np.all(data == saved_data)
 
 
-def test_fixed_window_patch_extractor(_patch_extr_vf_image):
-    """Test FixedWindowPatchExtractor for VF."""
+def test_sliding_window_patch_extractor(_patch_extr_vf_image):
+    """Test SlidingWindowPatchExtractor for VF."""
     input_img = pathlib.Path(_patch_extr_vf_image)
 
     stride = (20, 20)
@@ -273,7 +273,7 @@ def test_fixed_window_patch_extractor(_patch_extr_vf_image):
 
     patches = patchextraction.get_patch_extractor(
         input_img=input_img,
-        method_name="fixedwindow",
+        method_name="sliding",
         patch_size=patch_size,
         resolution=0,
         units="level",
@@ -293,7 +293,7 @@ def test_fixed_window_patch_extractor(_patch_extr_vf_image):
     # Test for integer (single) patch_size and stride input
     patches = patchextraction.get_patch_extractor(
         input_img=input_img,
-        method_name="fixedwindow",
+        method_name="sliding",
         patch_size=patch_size[0],
         resolution=0,
         units="level",
@@ -311,15 +311,15 @@ def test_fixed_window_patch_extractor(_patch_extr_vf_image):
     assert np.all(img_patches == img_patches_test)
 
 
-def test_fixedwindow_patch_extractor_ndpi(_sample_ndpi):
-    """Test FixedWindowPatchExtractor for ndpi image."""
+def test_sliding_patch_extractor_ndpi(_sample_ndpi):
+    """Test SlidingWindowPatchExtractor for ndpi image."""
     stride = (40, 20)
     patch_size = (400, 200)
     input_img = pathlib.Path(_sample_ndpi)
 
     patches = patchextraction.get_patch_extractor(
         input_img=input_img,
-        method_name="fixedwindow",
+        method_name="sliding",
         patch_size=patch_size,
         resolution=1,
         units="level",

--- a/tests/test_patch_extraction.py
+++ b/tests/test_patch_extraction.py
@@ -96,14 +96,6 @@ def test_get_patch_extractor(_source_image, _patch_extr_csv):
 
     assert isinstance(sliding_window, patchextraction.SlidingWindowPatchExtractor)
 
-    variable_window = patchextraction.get_patch_extractor(
-        input_img=input_img,
-        method_name="variablewindow",
-        patch_size=(200, 200),
-    )
-
-    assert isinstance(variable_window, patchextraction.VariableWindowPatchExtractor)
-
     with pytest.raises(MethodNotSupported):
         patchextraction.get_patch_extractor("unknown")
 

--- a/tests/test_patch_extraction.py
+++ b/tests/test_patch_extraction.py
@@ -87,7 +87,7 @@ def test_get_patch_extractor(_source_image, _patch_extr_csv):
 
     sliding_window = patchextraction.get_patch_extractor(
         input_img=input_img,
-        method_name="sliding",
+        method_name="slidingwindow",
         patch_size=(200, 200),
     )
 
@@ -259,7 +259,7 @@ def test_sliding_window_patch_extractor(_patch_extr_vf_image):
 
     patches = patchextraction.get_patch_extractor(
         input_img=input_img,
-        method_name="sliding",
+        method_name="slidingwindow",
         patch_size=patch_size,
         resolution=0,
         units="level",
@@ -279,7 +279,7 @@ def test_sliding_window_patch_extractor(_patch_extr_vf_image):
     # Test for integer (single) patch_size and stride input
     patches = patchextraction.get_patch_extractor(
         input_img=input_img,
-        method_name="sliding",
+        method_name="slidingwindow",
         patch_size=patch_size[0],
         resolution=0,
         units="level",
@@ -305,7 +305,7 @@ def test_sliding_patch_extractor_ndpi(_sample_ndpi):
 
     patches = patchextraction.get_patch_extractor(
         input_img=input_img,
-        method_name="sliding",
+        method_name="slidingwindow",
         patch_size=patch_size,
         resolution=1,
         units="level",

--- a/tiatoolbox/tools/patchextraction.py
+++ b/tiatoolbox/tools/patchextraction.py
@@ -218,48 +218,6 @@ class SlidingWindowPatchExtractor(PatchExtractor):
         raise NotImplementedError
 
 
-class VariableWindowPatchExtractor(PatchExtractor):
-    """Extract and merge patches using variable sized windows for images and labels.
-
-    Args:
-        stride(tuple(int)): stride in (x, y) direction for patch extraction.
-        label_patch_size(tuple(int)): network output label (width, height).
-
-    Attributes:
-        stride(tuple(int)): stride in (x, y) direction for patch extraction.
-        label_patch_size(tuple(int)): network output label (width, height).
-
-    """
-
-    def __init__(
-        self,
-        input_img,
-        patch_size,
-        resolution=0,
-        units="level",
-        stride=(1, 1),
-        pad_mode="constant",
-        pad_constant_values=0,
-        label_patch_size=None,
-    ):
-        super().__init__(
-            input_img=input_img,
-            patch_size=patch_size,
-            resolution=resolution,
-            units=units,
-            pad_mode=pad_mode,
-            pad_constant_values=pad_constant_values,
-        )
-        self.stride = stride
-        self.label_patch_size = label_patch_size
-
-    def __next__(self):
-        raise NotImplementedError
-
-    def merge_patches(self, patches):
-        raise NotImplementedError
-
-
 class PointsPatchExtractor(PatchExtractor):
     """Extracting patches with specified points as a centre.
 
@@ -313,8 +271,8 @@ def get_patch_extractor(method_name, **kwargs):
     """Return a patch extractor object as requested.
 
     Args:
-        method_name (str): name of patch extraction method, must be one of "point",
-          "sliding", "variablewindow".
+        method_name (str): name of patch extraction method, must be one of "point" or
+          "sliding".
         **kwargs: Keyword arguments passed to :obj:`PatchExtractor`.
 
     Returns:
@@ -331,8 +289,6 @@ def get_patch_extractor(method_name, **kwargs):
         patch_extractor = PointsPatchExtractor(**kwargs)
     elif method_name.lower() == "sliding":
         patch_extractor = SlidingWindowPatchExtractor(**kwargs)
-    elif method_name.lower() == "variablewindow":
-        patch_extractor = VariableWindowPatchExtractor(**kwargs)
     else:
         raise MethodNotSupported
 

--- a/tiatoolbox/tools/patchextraction.py
+++ b/tiatoolbox/tools/patchextraction.py
@@ -163,7 +163,7 @@ class PatchExtractor(ABC):
 
 
 class SlidingWindowPatchExtractor(PatchExtractor):
-    """Extract and merge patches using sliding fixed sized windows for images and labels.
+    """Extract patches using sliding fixed sized window for images and labels.
 
     Args:
         stride(int or tuple(int)): stride in (x, y) direction for patch extraction,
@@ -202,9 +202,6 @@ class SlidingWindowPatchExtractor(PatchExtractor):
 
         self._generate_location_df()
 
-    def merge_patches(self, patches):
-        raise NotImplementedError
-
 
 class PointsPatchExtractor(PatchExtractor):
     """Extracting patches with specified points as a centre.
@@ -242,16 +239,6 @@ class PointsPatchExtractor(PatchExtractor):
         )
         self.locations_df["y"] = self.locations_df["y"] - int(
             (self.patch_size[1] - 1) / 2
-        )
-
-    def merge_patches(self, patches=None):
-        """Merge patch is not supported by :obj:`PointsPatchExtractor`.
-        Calling this function for :obj:`PointsPatchExtractor` will raise an error. This
-        overrides the merge_patches function in the base class :obj:`PatchExtractor`
-
-        """
-        raise MethodNotSupported(
-            message="Merge patches not supported for PointsPatchExtractor"
         )
 
 

--- a/tiatoolbox/tools/patchextraction.py
+++ b/tiatoolbox/tools/patchextraction.py
@@ -262,7 +262,7 @@ def get_patch_extractor(method_name, **kwargs):
     """
     if method_name.lower() == "point":
         patch_extractor = PointsPatchExtractor(**kwargs)
-    elif method_name.lower() == "sliding":
+    elif method_name.lower() == "slidingwindow":
         patch_extractor = SlidingWindowPatchExtractor(**kwargs)
     else:
         raise MethodNotSupported

--- a/tiatoolbox/tools/patchextraction.py
+++ b/tiatoolbox/tools/patchextraction.py
@@ -161,18 +161,6 @@ class PatchExtractor(ABC):
 
         return self
 
-    def merge_patches(self, patches):
-        """Merge the patch-level results to get the overall image-level prediction.
-
-        Args:
-            patches: patch-level predictions
-
-        Returns:
-            image: merged prediction
-
-        """
-        raise NotImplementedError
-
 
 class SlidingWindowPatchExtractor(PatchExtractor):
     """Extract and merge patches using sliding fixed sized windows for images and labels.

--- a/tiatoolbox/tools/patchextraction.py
+++ b/tiatoolbox/tools/patchextraction.py
@@ -174,8 +174,8 @@ class PatchExtractor(ABC):
         raise NotImplementedError
 
 
-class FixedWindowPatchExtractor(PatchExtractor):
-    """Extract and merge patches using fixed sized windows for images and labels.
+class SlidingWindowPatchExtractor(PatchExtractor):
+    """Extract and merge patches using sliding fixed sized windows for images and labels.
 
     Args:
         stride(int or tuple(int)): stride in (x, y) direction for patch extraction,
@@ -314,7 +314,7 @@ def get_patch_extractor(method_name, **kwargs):
 
     Args:
         method_name (str): name of patch extraction method, must be one of "point",
-          "fixedwindow", "variablewindow".
+          "sliding", "variablewindow".
         **kwargs: Keyword arguments passed to :obj:`PatchExtractor`.
 
     Returns:
@@ -329,8 +329,8 @@ def get_patch_extractor(method_name, **kwargs):
     """
     if method_name.lower() == "point":
         patch_extractor = PointsPatchExtractor(**kwargs)
-    elif method_name.lower() == "fixedwindow":
-        patch_extractor = FixedWindowPatchExtractor(**kwargs)
+    elif method_name.lower() == "sliding":
+        patch_extractor = SlidingWindowPatchExtractor(**kwargs)
     elif method_name.lower() == "variablewindow":
         patch_extractor = VariableWindowPatchExtractor(**kwargs)
     else:

--- a/tiatoolbox/tools/patchextraction.py
+++ b/tiatoolbox/tools/patchextraction.py
@@ -247,7 +247,7 @@ def get_patch_extractor(method_name, **kwargs):
 
     Args:
         method_name (str): name of patch extraction method, must be one of "point" or
-          "sliding".
+          "slidingwindow".
         **kwargs: Keyword arguments passed to :obj:`PatchExtractor`.
 
     Returns:


### PR DESCRIPTION
- Change the class `FixedWindowPatchExtractor` name to  `SlidingWindowPatchExtractor` 
- get_patchextractor takes the `slidingwindow` as an argument. 
- Depreciate `VariableWindowPatchExtractor`