### PR TITLE
ENH: Enhance the `SlidingWindowPatchExtractor` for patches at the image margin

### DIFF
--- a/tiatoolbox/tools/patchextraction.py
+++ b/tiatoolbox/tools/patchextraction.py
@@ -325,10 +325,19 @@ class PatchExtractor(ABC):
         x_list = np.arange(0, image_shape[0], stride_shape[0])
         y_list = np.arange(0, image_shape[1], stride_shape[1])
 
-        if within_bound:
+        if within_bound == 2:
             sel = x_list + patch_shape[0] <= image_shape[0]
             x_list = x_list[sel]
             sel = y_list + patch_shape[1] <= image_shape[1]
+            y_list = y_list[sel]
+        elif within_bound == 1:
+            sel = x_list + patch_shape[0] < (
+                image_shape[0] + patch_shape[0] - stride_shape[0]
+            )
+            x_list = x_list[sel]
+            sel = y_list + patch_shape[1] < (
+                image_shape[1] + patch_shape[1] - stride_shape[1]
+            )
             y_list = y_list[sel]
 
         top_left_list = flat_mesh_grid_coord(x_list, y_list)


### PR DESCRIPTION
To deal with having patches with small context when using `within_bound=True`, I have changed the code to consider another form of `within_bound` which enables the user to extract patches on the image boundary up until the last patch goes beyond image extent. In other words, instead of being a binary argument, `within_bound` now can have three states:

- `within_bound=0`: Patches will not be within the image bounds, it means that there will be lots of patches with small bits of image in them, depending on the `stride_size` as the patches position are calculated based on it. This state is suitable for patch extraction for image inference when we want to predict with overlap.

- `within_bound=1`: Patches will be extracted from the image up until the last patch goes beyond image boundaries. In this state, the last patch (which has gone beyond the image boundaries) is also included. This state is suitable for patch extraction for training purposes. 
- `within_bound=2`: Patches will be extracted from the image up until the last patch goes beyond image boundaries. In this state, the last patch (which has gone beyond the image boundaries) is not included. This state is also suitable for patch extraction for training purposes but might exclude a large number of patches when big patch sizes (from low magnification) are being extracted.
