### PR TITLE
DEV: Move flake8 Earlier In Travis Config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ install:
 
 # Command to run tests, e.g. python setup.py test
 script:
-    - tox -e $(echo py$TRAVIS_PYTHON_VERSION | tr -d .)
     - tox -e flake8
+    - tox -e $(echo py$TRAVIS_PYTHON_VERSION | tr -d .)
 
 # Upload test coverage reports (codecov and deepsource)
 after_success:


### PR DESCRIPTION
I propose moving flake8 to run before purest on travis so that jobs will fail much quicker if there is an issue with flake8.