### PR TITLE
DEV: Extra Pre-commit Checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,10 @@
 repos:
+  - repo: https://github.com/pycqa/isort
+    rev: 5.8.0
+    hooks:
+      - id: isort
   - repo: https://github.com/psf/black
-    rev: 20.8b1 # Replace by any tag/version: https://github.com/psf/black/tags
+    rev: 20.8b1 # Replace with any tag/version: https://github.com/psf/black/tags
     hooks:
       - id: black
         language_version: python3 # Should be a command that runs python3.6+
@@ -8,4 +12,24 @@ repos:
     rev: 3.7.9
     hooks:
       - id: flake8
-        additional_dependencies: [flake8-bugbear]
+        additional_dependencies: [
+          flake8-bugbear, # Detect potential bugs
+          flake8-isort, # Check import ordering
+          flake8-comprehensions, # Suggestions for better list/set/dict comprehensions 
+          flake8-mutable, # Check for mutable default arguments
+          flake8-use-fstring, # Encourages use of f-strings vs old style
+          flake8-simplify, # Suggestions to simplify code
+          pep8-naming, # Check PEP8 class naming
+          flake8-eradicate, # Find dead/commented out code
+          flake8-builtins, # Check for built-ins being used as variables
+          flake8-cognitive-complexity, # Check max function complexity
+          flake8-expression-complexity, # Check max expression complexity
+          flake8-return, # Check return statements
+          flake8-spellcheck, # Spelling checker
+          flake8-pytest-style, # Check against pytest style guide
+          flake8-fixme, # Check for FIXME, TODO, and XXX left in comments
+          flake8-sql, # Check SQL statement style
+          nitpick, # Check that black, flake8, isort have compaible options
+          flake8-logging-format, # Validate (lack of) logging format strings
+          flake8-pie, # Misc. linting rules
+        ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,10 @@ universal = 1
 exclude = docs, *__init__*
 max-line-length = 88
 extend-ignore = E203 # For black compatibility
+spellcheck-targets = comments
+dictionaries = en_US,python,technical
+max-cognitive-complexity = 7
+max-expression-complexity = 7
 
 [aliases]
 test = pytest
@@ -25,3 +29,9 @@ test = pytest
 [tool:pytest]
 collect_ignore = ['setup.py']
 
+[isort]
+profile = black
+multi_line_output = 3
+skip_gitignore = True
+line_length = 88
+filter_files = True

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -1,0 +1,2 @@
+# Spell checking whitelist for flake8-spellcheck
+pyright


### PR DESCRIPTION
I have compiled many extra checks for pre-commit, some of which are the same as those used by deepsource. Proposed new additions to pre-commit:

- isort: Sort and group imports (stdlibrary, 3rd party, current package)
- flake8-isort: Check import ordering
- flake8-comprehensions: Suggestions for better comprehensions
- flake8-mutable: Check for mutable default arguments
- flake8-use-fstring: Use of f-strings vs old style format strings
- flake8-simplify: Suggestions to simplify code
- pep8-naming: Check PEP8 class naming
- flake8-eradicate: Find dead/commented out code
- flake8-builtins: Check for built-ins being used as variables
- flake8-cognitive-complexity: Check max function complexity (set in setup.cfg)
- flake8-expression-complexity: Check max expression complexity (set in setup.cfg)
- flake8-return: Check return statements (no redundant assignments)
- flake8-spellcheck: Spelling checker (comments only, new words in whitelist.txt)
- flake8-pytest-style: Check against pytest style guide
- flake8-fixme: Check for FIXME, TODO, and XXX left in comments
- flake8-sql: Check SQL statement style
- nitpick: Check that black, flake8, isort have compaible options
- flake8-logging-format: Validate (lack of) logging format strings
- flake8-pie: Misc. linting rules

Of course we don't have to use all of these but I went through a bunch of them and tried them out. These were the ones that looked helpful and did not have any obvious annoying bugs or conflicts.

Some of these could be added to travis also if that would be useful. 