### PR TITLE
DEV: Use requirements file for readthedocs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,7 +10,7 @@ sphinx:
   configuration: docs/conf.py
 
 # Build documentation with MkDocs
-#mkdocs:
+# mkdocs:
 #  configuration: mkdocs.yml
 
 # Optionally build your docs in additional formats such as PDF
@@ -20,8 +20,10 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
+  version: "3.7"
+  install:
+      - requirements: requirements.txt
 
 # Use conda to to manage environment
-conda:
-  environment: requirements.dev.conda.yml
+# conda:
+#  environment: requirements.dev.conda.yml

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,6 +18,13 @@ formats:
   - pdf
   - epub
 
+# Install apt packages
+build:
+  apt_packages:
+    - openslide-tools
+    - libopenjp2-7-dev
+    - libopenjp2-tools
+
 # Optionally set the version of Python and requirements required to build your docs
 python:
   version: "3.7"

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -30,7 +30,3 @@ python:
   version: "3.7"
   install:
       - requirements: requirements.txt
-
-# Use conda to to manage environment
-# conda:
-#  environment: requirements.dev.conda.yml


### PR DESCRIPTION
Conda build on readthedocs causes build errors
To resolve the above issue, I have
- added requirements.txt in .readthedocs.yml 
- added apt-get installation for openjpeg and openslide
- removed conda build 

The result is much faster build time on readthedocs and the out of memory issue is resolved now.